### PR TITLE
removing empty directories search after each ports

### DIFF
--- a/files/portmaster.8
+++ b/files/portmaster.8
@@ -335,6 +335,8 @@ hide details of the port build and install in a log file
 prevents 'make clean' from being run after building
 .It Fl B
 prevents creation of the backup package for the installed port
+.It Fl E
+always remove empty directory in WRKDIRPREFIX if set after each building
 .It Fl b
 create and keep a backup package of an installed port
 .It Fl g

--- a/portmaster
+++ b/portmaster
@@ -176,6 +176,11 @@ parent_exit () {
 			fi
 			sleep 2
 		done
+		if [ -n "$ALWAYS_REMOVE_EMPTY_WRKDIR" ]; then
+			pm_v "===>>> Removing empty directories from WRKDIRPREFIX"
+			[ -n "$needws" ] && echo '' || pm_v
+			find $PM_WRKDIRPREFIX -depth -mindepth 1 -type d -empty -delete 2>/dev/null
+		fi
 	fi
 
 	case "$DISPLAY_LIST" in
@@ -453,6 +458,7 @@ usage () {
 	echo ''
 	echo "--force-config run 'make config' for all ports (overrides -G)"
 	echo "-C prevents 'make clean' from being run before building"
+	echo "-E always remove empty directory in WRKDIRPREFIX if set after each building"
 	echo "-G prevents 'make config'"
 	echo "-H hide details of the port build and install in a log file"
 	echo "-K prevents 'make clean' from being run after building"
@@ -713,11 +719,12 @@ set -- $newopts
 unset var newopts
 
 # Save switches for potential child processes
-while getopts 'BCDFGHKLPRabde:fghilm:nop:r:stvwx:y' COMMAND_LINE_ARGUMENT ; do
+while getopts 'BCDEFGHKLPRabde:fghilm:nop:r:stvwx:y' COMMAND_LINE_ARGUMENT ; do
 	case "${COMMAND_LINE_ARGUMENT}" in
 	B)	NO_BACKUP=Bopt; ARGS="-B $ARGS" ;;
 	C)	DONT_PRE_CLEAN=Copt; ARGS="-C $ARGS" ;;
 	D)	DONT_SCRUB_DISTFILES=Dopt; ARGS="-D $ARGS" ;;
+	E)	ALWAYS_REMOVE_EMPTY_WRKDIR=Eopt; ARGS="-E $ARGS" ;;
 	F)	FETCH_ONLY=Fopt; ARGS="-F $ARGS" ;;
 	G)	[ -z "$PM_FORCE_CONFIG" ] && {
 			PM_NO_MAKE_CONFIG=Gopt; ARGS="-G $ARGS"; } ;;


### PR DESCRIPTION
Removed without much sense line that search for empty directories in WRKDIRPREFIX after each port. If you define WRKDIRPREFIX (such as /tmp) and portmaster execute with -C and -K flags, this procedure greatly increases the time portmaster because /tmp/usr/ports have are large structures while the deletion of empty directories there is no benefit
