### PR TITLE
store list of remaining ports after failure also in text-file

### DIFF
--- a/portmaster
+++ b/portmaster
@@ -254,9 +254,12 @@ parent_exit () {
 	fi
 
 	if [ -n "$1" -a -n "${PM_NEEDS_UPDATE# }" -a -n "$PM_BUILDING" -a -z "$FETCH_ONLY" ]; then
+		echo "${0##*/} <flags>${PM_NEEDS_UPDATE}" > ${TMPDIR}/portmasterfail.txt
 		echo ''
 		echo "===>>> You can restart from the point of failure with this command line:"
 		echo "       ${0##*/} <flags>${PM_NEEDS_UPDATE}"
+		echo ''
+		echo "This command has been saved to ${TMPDIR}/portmasterfail.txt"
 		echo ''
 	fi
 }


### PR DESCRIPTION
when a port upgrade fails portmaster will print out the entire list of remaining ports, which can be very long list. this list will not always fit into the buffer of the console or the copy-command. therefere we also store the list in an file
Thanks to Warren Block for writing this patch
