### PR TITLE
Support user configurable options for package creation

### DIFF
--- a/portmaster
+++ b/portmaster
@@ -1914,9 +1914,9 @@ pm_pkg_create () {
 	pm_cd $pkgdir || fail "Cannot cd into $pkgdir to create a package"
 	local pkg_create
 	if [ -z "$use_pkgng" ]; then
-		pkg_create="pkg_create -b"
+		pkg_create="pkg_create ${PM_PKG_CREATE_OPTS} -b"
 	else
-		pkg_create="pkg create "
+		pkg_create="pkg create ${PM_PKG_CREATE_OPTS}"
 	fi
 	if $PM_SU_CMD $pkg_create $2; then
 		if [ "$1" = "$pbu" ]; then


### PR DESCRIPTION
  . Add ${PM_PKG_CREATE_OPTS} to the package creation command.  This allows
    users to specify options for package creation in portmasterrc.

    I've used this to specify PM_PKG_CREATE_OPTS="-f tgz" which shortens
    package creation time considerably, particularly for larger packages.
    For example, on my machine creating a backup package for games/wesnoth
    went from 270 seconds to 35 seconds, or almost a factor of 9.