### PR TITLE
A collection of changes created while working on FLAVOR support

### DIFF
--- a/files/portmaster.8
+++ b/files/portmaster.8
@@ -243,7 +243,7 @@ If there is no
 .Fl B
 option specified when updating an existing port,
 a backup package will be created before
-.Xr pkg_delete 1
+.Xr pkg-delete 8
 is called.
 If you are using the
 .Fl b
@@ -495,7 +495,7 @@ answer no to all user prompts for the features below
 answer yes to all user prompts for the features below
 .It [-n|y] [-b] [-D|d] Fl e Ar name/glob of a single port directory in /var/db/pkg
 expunge a port using
-.Xr pkg_delete 1 ,
+.Xr pkg-delete 8 ,
 and optionally remove all distfiles.
 Calls
 .Fl s
@@ -575,7 +575,7 @@ and
 .Nm
 attempts to use both of these variables in the same
 way that
-.Xr pkg_add 1
+.Xr pkg-add 8
 does.
 .Pp
 The
@@ -630,7 +630,7 @@ writable by the unprivileged user.
 By default
 .Nm
 creates backup packages of installed ports before it runs
-.Xr pkg_delete 1
+.Xr pkg-delete 8
 during an update.
 If that package creation fails it is treated as a serious
 error and the user is prompted.
@@ -866,11 +866,13 @@ to avoid rebuilding ports already rebuilt on previous runs.
 However the first method (delete everything and reinstall) is preferred.
 .Sh SEE ALSO
 .Xr make 1 ,
-.Xr pkg_add 1 ,
-.Xr pkg_delete 1 ,
 .Xr su 1 ,
+.Xr pkg 7 ,
 .Xr ports 7 ,
 .Xr ldconfig 8 ,
+.Xr pkg 8 ,
+.Xr pkg-add 8 ,
+.Xr pkg-delete 8 ,
 .Xr sudo 8
 .Sh AUTHORS
 This

--- a/portmaster
+++ b/portmaster
@@ -498,7 +498,7 @@ usage () {
 	echo '-n answer no to all user prompts for the features below'
 	echo '-y answer yes to all user prompts for the features below'
 	echo ''
-	echo '[-n|y] [-b] [-D|d] -e expunge one port via pkg_delete, and remove its distfiles'
+	echo '[-n|y] [-b] [-D|d] -e expunge one port via pkg delete, and remove its distfiles'
 	echo '[-n|y] [-b] [-D|d] -s clean out stale ports that used to be depended on'
 	echo ''
 	echo '[-t] [-n] --clean-distfiles offer to delete stale distfiles'
@@ -1553,7 +1553,7 @@ pm_pkg_create () {
 	fi
 
 	pm_cd $pkgdir || fail "Cannot cd into $pkgdir to create a package"
-	if $PM_SU_CMD pkg create ${PM_PKG_CREATE_OPTS} $2; then
+	if $PM_SU_CMD pkg create $2; then
 		if [ "$1" = "$pbu" ]; then
 			if [ -n "$BACKUP" ]; then
 				echo "	===>>> Package saved to $1" ; echo ''
@@ -1963,7 +1963,6 @@ if [ -n "$CLEAN_STALE" ]; then
 		fi
 
 		echo '' ; pkg info -f $iport
-		pkg_delete="pkg delete"
 
 		get_answer_yn n "\t===>>> ${iport} is no longer depended on, delete"
 		case "$?" in
@@ -2361,7 +2360,7 @@ dependency_check () {
 					if [ "${d_port#$pd/}" = "$portdir" ]; then
 						echo -e "\n===>>> $origin seems to depend on $portdir"
 						echo '       which looks like a dependency loop'
-						fail "Try pkg_updating $portdir"
+						fail "Try pkg updating $portdir"
 					fi
 
 					echo ''
@@ -3384,7 +3383,7 @@ fetch_package () {
 		fi
 		[ -z "$PM_PACKAGES_LOCAL" ] && echo "	${sitepath}"
 		echo ''
-		echo "       Check the pkg_add(1) man page for information"
+		echo "       Check the pkg-add(8) man page for information"
 		echo "       on setting the PACKAGESITE environment variable"
 		[ "$PM_PACKAGES" = only -a -z "$FETCH_ONLY" ] && fail $ponly_err
 		if [ -n "$FETCH_ONLY" ]; then
@@ -3546,8 +3545,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 		    grep -v ^$LOCALBASE_COMPAT > $pm_mktemp_file
 
 		unset temp
-		pkglist="pkg query %Fp"
-		for file in `$pkglist $UPGRADE_PORT |
+		for file in `pkg query %Fp $UPGRADE_PORT |
 		    sort - $pm_mktemp_file | uniq -d`; do
 			temp="${temp}$file "
 		done
@@ -3571,7 +3569,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 	if [ -n "$REPLACE_ORIGIN" -a -n "$ro_upg_port" ]; then
 		# Delete any existing versions of the old port
 		np_orphan=`pkg query "%a" $ro_upg_port`
-		pm_sv "Running pkg_delete for $ro_upg_port"
+		pm_sv "Running pkg delete for $ro_upg_port"
 		pm_pkg_delete_s $ro_upg_port
 	fi
 
@@ -3594,7 +3592,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 		if [ "${np_orphan:-1}" -eq 1 ]; then
 			np_orphan=`pkg query "%a" $upg_port`
 		fi
-		pm_sv "Running pkg_delete for $upg_port"
+		pm_sv "Running pkg delete for $upg_port"
 		pm_pkg_delete_s $upg_port
 	fi
 
@@ -3659,7 +3657,7 @@ else
 	[ -n "$local_package" ] && ppd=${LOCAL_PACKAGEDIR}/All
 
 	echo "===>>> Installing package"
-	if $PM_SU_CMD pkg_add --no-deps --force ${ppd}/${latest_pv}.tbz; then
+	if $PM_SU_CMD pkg add --accept-missing --force ${ppd}/${latest_pv}.tbz; then
 		if [ -n "$PM_DELETE_PACKAGES" ]; then
 			pm_v "===>>> Deleting ${latest_pv}.tbz"
 			pm_unlink_s ${ppd}/${latest_pv}.tbz
@@ -3684,8 +3682,7 @@ echo ''
 temp=`find $LOCALBASE_COMPAT -type d -empty 2>/dev/null`
 if [ -z "$temp" ] && [ -d "$LOCALBASE_COMPAT" ]; then
 	unset files
-	pkglist="pkg query %Fp"
-	for file in `$pkglist $new_port`; do
+	for file in `pkg query %Fp $new_port`; do
 		[ -f "${LOCALBASE_COMPAT}/${file##*/}" ] &&
 			files="${files}${LOCALBASE_COMPAT}/${file##*/} "
 	done

--- a/portmaster
+++ b/portmaster
@@ -318,6 +318,9 @@ pm_mktemp () {
 		fail "mktemp for $1 failed:\n       ${pm_mktemp_file#mktemp: }"
 }
 pm_unlink () { [ -e "$1" ] && /bin/unlink $1; }
+pm_islocked	() { [ -n "$1" ] || return 1;
+			[ -e "$pdb/$1/+IGNOREME" ] && pkg info -e "$1" ||
+			[ `pkg query %k "$1"` -eq "1" ]; }
 
 # Superuser versions for commands that need root privileges
 
@@ -553,7 +556,7 @@ origin_from_pdb () {
 
 	case "$1" in bsdpan-*) return 3 ;; esac
 
-	if [ -e "$pdb/$1/+IGNOREME" ] && pkg info -e $1; then
+	if pm_islocked "$1"; then
 		if [ -n "$PM_VERBOSE" -o -n "$LIST_ORIGINS" ]; then
 			# An error above doesn't necessarily mean there's
 			# a problem in +MANIFEST, so don't mention it
@@ -985,7 +988,7 @@ find_moved_port () {
 	for l in `grep "^$sf|" $pd/MOVED`; do
 		case "$l" in
 		${sf}\|\|*) [ -n "$iport" ] || iport=`iport_from_origin $sf`
-			if [ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport; then
+			if pm_islocked $iport; then
 				if [ -n "$PM_VERBOSE" ]; then
 					echo ''
 					echo "	===>>> The $sf port has been deleted"
@@ -1020,7 +1023,7 @@ find_moved_port () {
 		echo ''
 
 		[ -n "$iport" ] || iport=`iport_from_origin $sf`
-		[ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport || return 1
+		pm_islocked $iport || return 1
 	fi
 	return 0
 }
@@ -1433,7 +1436,7 @@ check_for_updates () {
 
 	if [ -z "$do_update" -a -z "$skip" -a -z "$PM_INDEX_ONLY" ] && [ -d "$pd/$origin" ]; then
 		if ! pm_cd $pd/$origin; then
-			if [ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport; then
+			if pm_islocked "$iport"; then
 				echo "	===>>> Warning: Unable to cd to $pd/$origin"
 				echo "	===>>> Continuing due to $pdb/$iport/+IGNOREME"
 				echo ''
@@ -1450,7 +1453,7 @@ check_for_updates () {
 
 		# If the port has moved and no +IGNOREME, we have to update it
 		if [ -n "$moved_npd" ]; then
-			if [ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport; then
+			if pm_islocked "$iport"; then
 				echo "	===>>> Continuing due to $pdb/$iport/+IGNOREME"
 				echo ''
 				CUR_DEPS="${CUR_DEPS}${iport}:${origin}:"
@@ -1496,7 +1499,7 @@ check_for_updates () {
 	if [ -n "$LIST_PLUS" ]; then
 		if [ -z "$moved_npd" ]; then
 			echo "	===>>> New version available: $port_ver"
-			if [ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport; then
+			if pm_islocked "$iport"; then
 				echo "	===>>> +IGNOREME file is present for $1"
 			fi
 			pm_cd_pd $origin && check_state
@@ -2012,9 +2015,9 @@ check_interactive () {
 	case "$INTERACTIVE_YES" in *:${1}:*) return 0 ;; esac
 	case "$INTERACTIVE_NO" in *:${1}:*) return 1 ;; esac
 
-	if [ -e "$pdb/$1/+IGNOREME" ] && pkg info -e $1; then
+	if pm_islocked $1; then
 		echo ''
-		echo "===>>> +IGNOREME file is present for $1"
+		echo "===>>> package is locked or +IGNOREME file is present for $1"
 		echo ''
 		get_answer_g n y "===>>> Update ${1}${update_to}? y/n"
 
@@ -3038,7 +3041,7 @@ if [ -z "$PM_INDEX_ONLY" ] && [ ! -d "$pd/$portdir" ]; then
 fi
 [ -z "$upg_port" -a -z "$REPLACE_ORIGIN" ] && upg_port=`iport_from_origin ${portdir}`
 
-if [ -e "$pdb/$upg_port/+IGNOREME" ] && pkg info -e $upg_port; then
+if pm_islocked "$upg_port"; then
 	# Adding to CUR_DEPS means we will not get here in the build
 	if [ -z "$PM_BUILDING" ]; then
 		# Only need to prompt for this once if -ai

--- a/portmaster
+++ b/portmaster
@@ -152,7 +152,7 @@ parent_exit () {
 	[ -n "$need_kbc" ] && kill_bad_children
 
 	[ -n "$pbu" ] && pbu=`find $pbu -type d -empty 2>/dev/null`
-	if [ -d "$pbu" ]; then
+	if pm_isdir "$pbu"; then
 		pm_sv 'Removing empty backup package directory'
 		pm_rmdir_s $pbu
 	fi
@@ -309,6 +309,8 @@ pm_cd     () { builtin cd $1 2>/dev/null || return 1; }
 pm_cd_pd  () { [ -n "$PM_INDEX_ONLY" ] && return 2;
 		builtin cd $pd/$1 2>/dev/null ||
 		fail "Cannot cd to port directory: $pd/$1"; }
+pm_isdir	() { builtin test -d "$1"; }
+pm_isdir_pd	() { builtin test -d "$pd/$1"; }
 pm_kill   () { kill $* >/dev/null 2>/dev/null; }
 pm_make   () { ( unset -v CUR_DEPS INSTALLED_LIST PM_DEPTH build_l PM_URB_LIST;
 		 /usr/bin/nice /usr/bin/make $PM_MAKE_ARGS $*; ); }
@@ -348,7 +350,7 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 	if [ -z "$pd" ]; then
 		if [ -z "$PORTSDIR" ]; then
 			pd=`pm_make_b -f/usr/share/mk/bsd.port.mk -V PORTSDIR 2>/dev/null`
-			[ -z "$pd" ] && [ -d /usr/ports ] && pd=/usr/ports
+			[ -z "$pd" ] && pm_isdir /usr/ports && pd=/usr/ports
 		else
 			pd=$PORTSDIR
 		fi
@@ -361,14 +363,14 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 
 	if [ -z "$pdb" ]; then
 		if [ -z "$PKG_DBDIR" ]; then
-			[ -d /var/db/pkg ] && pdb=/var/db/pkg
+			pm_isdir /var/db/pkg && pdb=/var/db/pkg
 			[ -z "$pdb" ] &&
 				pdb=`pm_make -f/usr/share/mk/bsd.port.mk -V PKG_DBDIR 2>/dev/null`
 		else
 			pdb=$PKG_DBDIR
 		fi
 		if [ -z "$pdb" ]; then
-			if [ -d /var/db/pkg ]; then
+			if pm_isdir /var/db/pkg; then
 				pdb='/var/db/pkg'
 			else
 				fail 'The value of PKG_DBDIR cannot be empty'
@@ -377,7 +379,7 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 	fi
 	export pdb
 
-	[ -z "$port_dbdir" ] && [ -d /var/db/ports ] && port_dbdir=/var/db/ports
+	[ -z "$port_dbdir" ] && pm_isdir /var/db/ports && port_dbdir=/var/db/ports
 	[ -z "$port_dbdir" ] &&
 		port_dbdir=`pm_make_b -f/usr/share/mk/bsd.port.mk -V PORT_DBDIR 2>/dev/null`
 	[ -n "$port_dbdir" ] && export port_dbdir
@@ -887,7 +889,7 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 			fail 'The value of PORTSDIR cannot be empty'
 		fi
 	else
-		if [ -n "$pd" ] && [ -d "$pd" ]; then
+		if [ -n "$pd" ] && pm_isdir "$pd" ]; then
 			export pd
 		else
 			if [ -z "$DONT_SCRUB_DISTFILES" ]; then
@@ -901,7 +903,7 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 	if [ -z "$DISTDIR" -a "$PM_PACKAGES" != only -a -z "$CHECK_DEPENDS" -a \
 	    -z "$CHECK_PORT_DBDIR" -a -z "$LIST_ORIGINS" ]; then
 		if ! DISTDIR=`pm_make_b -f/usr/share/mk/bsd.port.mk -V DISTDIR 2>/dev/null`; then
-			if [ ! -d "$PWD" ]; then
+			if ! pm_isdir "$PWD"; then
 				echo ''
 				echo "===>>> Your current working directory no longer seems to exist"
 				fail 'Try: cd'
@@ -1042,7 +1044,7 @@ read_distinfos () {
 	echo ''
 
 	all_pkgs_by_origin | while read iport origin; do
-		if [ ! -d "$pd/$origin" ]; then
+		if ! pm_isdir_pd "$origin"; then
 			find_moved_port $origin $iport nonfatal >/dev/null
 			[ -n "$moved_npd" ] || continue
 			origin=$moved_npd
@@ -1096,7 +1098,7 @@ read_distinfos_all () {
 		case "${origin#$pd/}" in
 		Mk/*|T*|distfiles/*|packages/*|*/[Mm]akefile*|CVS/*|*/CVS|base/*) continue ;; esac
 
-		[ -d "$origin" ] || continue
+		pm_isdir "$origin" ] || continue
 
 		if [ -s "${origin}/distinfo" ]; then
 			distinfo="${origin}/distinfo"
@@ -1232,7 +1234,7 @@ if [ -n "$CLEAN_PACKAGES" ]; then
 		origin=${origin#origin: }
 
 		if [ -z "$PM_INDEX" ]; then
-			if [ -d "$pd/$origin" ]; then
+			if pm_isdir_pd "$origin"; then
 				pm_cd $pd/$origin && port_ver=`pm_make -V PKGNAME`
 				[ -n "$port_ver" ] || fail "Is $pd/$origin/Makefile missing?"
 			else
@@ -1320,14 +1322,14 @@ if [ -n "$CHECK_DEPENDS" ]; then
 fi
 
 if [ -n "$CHECK_PORT_DBDIR" ]; then
-	[ -d "$port_dbdir" ] ||
+	pm_isdir "$port_dbdir" ||
 		fail 'PORT_DBIR is empty, or the directory $port_dbdir does not exist'
 
 	unique_list=':'
 
 	echo "===>>> Building list of installed port names"; echo ''
 	while read pkg origin; do
-		if [ ! -d "$pd/$origin" ]; then
+		if ! pm_isdir_pd "$origin"; then
 			find_moved_port $origin $pkg nonfatal >/dev/null
 			[ -n "$moved_npd" ] || continue
 			origin=$moved_npd
@@ -1530,7 +1532,7 @@ init_packages () {
 
 	pbu=$PACKAGES/portmaster-backup
 
-	if [ ! -d "$pbu" ]; then
+	if ! pm_isdir "$pbu"; then
 		pm_sv Creating $pbu
 		pm_mkdir_s $pbu
 	fi
@@ -1641,7 +1643,7 @@ find_dl_distfiles () {
 		pm_unlink_s $dist_list
 
 		local dir=`find ${dist_list%/distfiles} -type d -empty 2>/dev/null`
-		if [ -d "$dir" ]; then
+		if pm_isdir "$dir"; then
 			pm_sv Deleting empty $dir directory
 			pm_rmdir_s $dir
 		fi
@@ -1724,7 +1726,7 @@ make_port_subdir () {
 set_distfiles_and_subdir () {
 	[ -z "$dist_list_files" ] && find_dl_distfiles $1
 
-	if [ -d "$pd/$1" ]; then
+	if pm_isdir_pd "$1"; then
 		pm_cd_pd $1
 	else
 		return 1
@@ -1737,7 +1739,7 @@ set_distfiles_and_subdir () {
 
 	[ -n "$full_port_subdir" ] || make_port_subdir
 
-	if [ -d "$full_port_subdir" ]; then
+	if pm_isdir "$full_port_subdir"; then
 		pm_cd $full_port_subdir || fail "cd to $full_port_subdir failed!"
 	else
 		echo ''
@@ -1905,7 +1907,7 @@ if [ -n "$LIST" -o -n "$LIST_PLUS" ]; then
 fi
 
 if [ -n "$EXPUNGE" ]; then
-	if [ ! -d "$pdb/$EXPUNGE" ] || ! pkg info -e $EXPUNGE; then
+	if ! pm_isdir "$pdb/$EXPUNGE" || ! pkg info -e $EXPUNGE; then
 		find_glob_dirs $EXPUNGE
 		case $? in
 		1)	fail "No such port: $EXPUNGE" ;;
@@ -2589,12 +2591,12 @@ multiport () {
 		port=${port#$pdb/}
 		case "$port" in
 		*/*)	port=${port#$pd/}
-			if [ -n "$PM_INDEX_ONLY" ] || [ -d "$pd/${port}" ]; then
+			if [ -n "$PM_INDEX_ONLY" ] || pm_isdir_pd "${port}"; then
 				worklist_temp="$worklist_temp $port"
 			else
 				fail "$pd/${port} does not exist"
 			fi ;;
-		*)	if [ -d "$pdb/$port" ] && pkg info -e $port; then
+		*)	if pm_isdir "$pdb/$port" && pkg info -e $port; then
 				worklist_temp="$worklist_temp $port"
 			else
 				find_glob_dirs $port
@@ -2776,7 +2778,7 @@ if [ "$$" -eq "$PM_PARENT_PID" -a -z "$SHOW_WORK" ]; then
 			LOCALBASE_COMPAT="$PLB/lib/compat/pkg"
 		else
 			[ -n "$PM_INDEX" ] && PLB=`head -1 $PM_INDEX | cut -f 3 -d\| 2>/dev/null`
-			if [ -n "$PLB" ] && [ -d "$PLB" ]; then
+			if [ -n "$PLB" ] && pm_idsdir "$PLB"; then
 				LOCALBASE_COMPAT="${PLB}/lib/compat/pkg"
 			else
 				echo "===>>> Unable to determine the value of LOCALBASE"
@@ -2829,7 +2831,7 @@ if [ "$$" -eq "$PM_PARENT_PID" -a -z "$SHOW_WORK" ]; then
 	if [ -n "$MAKE_PACKAGE" -a -z "$FETCH_ONLY" ]; then
 		init_packages_var
 
-		if [ ! -d "$PACKAGES" ]; then
+		if ! pm_isdir "$PACKAGES"; then
 			pm_sv Creating $PACKAGES
 			pm_mkdir_s $PACKAGES
 		fi
@@ -2953,7 +2955,7 @@ if [ -z "$REPLACE_ORIGIN" ]; then
 			*)	echo '' ; no_valid_port ;;
 			esac
 		done ;;
-	*)	[ -d "$pdb/$argv" ] && \
+	*)	pm_isdir "$pdb/$argv" && \
 			pkg info -e $argv && \
 			upg_port=$argv ;;
 	esac
@@ -2971,7 +2973,7 @@ if [ -z "$REPLACE_ORIGIN" ]; then
 else
 	portdir="${1#$pd/}" ; portdir="${portdir%/}"
 	if [ -z "$PM_INDEX_ONLY" ]; then
-		[ -d "$pd/$portdir" ] || missing=missing
+		pm_isdir_pd "$portdir" ] || missing=missing
 	else
 		parse_index $portdir name >/dev/null || missing=missing
 	fi
@@ -2988,7 +2990,7 @@ else
 
 	case "$arg2" in
 	*/*)	ro_opd=$arg2 ; ro_upg_port=`iport_from_origin $ro_opd` ;;
-	*)	if [ -d "$pdb/$arg2" ] && pkg info -e $arg2; then
+	*)	if pm_isdir "$pdb/$arg2" && pkg info -e $arg2; then
 			ro_upg_port=$arg2
 		else
 			find_glob_dirs $arg2 && ro_upg_port=${glob_dirs#$pdb/}
@@ -3031,10 +3033,10 @@ elif [ -z "$portdir" ]; then
 	no_valid_port
 fi
 
-if [ -z "$PM_INDEX_ONLY" ] && [ ! -d "$pd/$portdir" ]; then
+if [ -z "$PM_INDEX_ONLY" ] && ! pm_isdir_pd "$portdir"; then
 	find_moved_port $portdir $upg_port || no_valid_port
 	[ -n "$moved_npd" ] || no_valid_port
-	[ -d "$pd/$moved_npd" ] || no_valid_port
+	pm_isdir_pd "$moved_npd" ] || no_valid_port
 
 	[ "$$" -eq "$PM_PARENT_PID" ] && parent_exit
 	exec $0 $ARGS -o $moved_npd $upg_port
@@ -3276,7 +3278,7 @@ fetch_package () {
 		export ppd
 	fi
 
-	[ -d "$ppd" ] || { pm_sv Creating $ppd; pm_mkdir_s $ppd; }
+	pm_isdir "$ppd" ] || { pm_sv Creating $ppd; pm_mkdir_s $ppd; }
 
 	if [ -z "$FETCH_ARGS" ]; then
 		FETCH_ARGS=`pm_make -f/usr/share/mk/bsd.port.mk -V FETCH_ARGS 2>/dev/null`
@@ -3553,7 +3555,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 			temp="${temp}$file "
 		done
 		if [ -n "$temp" ]; then
-			if [ ! -d "$LOCALBASE_COMPAT" ]; then
+			if ! pm_isdir "$LOCALBASE_COMPAT"; then
 				pm_sv "Creating $LOCALBASE_COMPAT for -w"
 				pm_mkdir_s $LOCALBASE_COMPAT
 			fi
@@ -3683,7 +3685,7 @@ echo ''
 # Remove saved libs that match newly installed files
 
 temp=`find $LOCALBASE_COMPAT -type d -empty 2>/dev/null`
-if [ -z "$temp" ] && [ -d "$LOCALBASE_COMPAT" ]; then
+if [ -z "$temp" ] && pm_isdir "$LOCALBASE_COMPAT"; then
 	unset files
 	for file in `pkg query %Fp $new_port`; do
 		[ -f "${LOCALBASE_COMPAT}/${file##*/}" ] &&
@@ -3699,7 +3701,7 @@ if [ -z "$temp" ] && [ -d "$LOCALBASE_COMPAT" ]; then
 fi
 
 [ -z "$temp" ] && temp=`find $LOCALBASE_COMPAT -type d -empty 2>/dev/null`
-if [ -d "$temp" ]; then
+if pm_isdir "$temp"; then
 	pm_sv Deleting the empty $LOCALBASE_COMPAT
 	pm_rmdir_s $temp
 fi


### PR DESCRIPTION
I have identified and removed a few more references to the pre-PKG_NG tools in portmaster and portmaster.8. The fixes to portmaster.8 are in response to issue #49 by rumpelsepp, but extend on the patch he provided.

The 2 other commits are to introduce abstractions for a few tests:

pm_islocked combines the previously existing tests for the +IGNOREME flag with a new test for the lock state of the package.

pm_isdir and pm_isdir_pd just make it easier to search for program lines that test for the existence of a directory. The latter is modified to strip a flavor mark (e.g. \@py36) from the passed origin in my version that adds FLAVOR support. The need for the latter triggered the introduction of the former ...
