### PR TITLE
Collection of fixes for flavor support

### DIFF
--- a/files/portmaster.8
+++ b/files/portmaster.8
@@ -243,7 +243,7 @@ If there is no
 .Fl B
 option specified when updating an existing port,
 a backup package will be created before
-.Xr pkg_delete 1
+.Xr pkg-delete 8
 is called.
 If you are using the
 .Fl b
@@ -495,7 +495,7 @@ answer no to all user prompts for the features below
 answer yes to all user prompts for the features below
 .It [-n|y] [-b] [-D|d] Fl e Ar name/glob of a single port directory in /var/db/pkg
 expunge a port using
-.Xr pkg_delete 1 ,
+.Xr pkg-delete 8 ,
 and optionally remove all distfiles.
 Calls
 .Fl s
@@ -575,7 +575,7 @@ and
 .Nm
 attempts to use both of these variables in the same
 way that
-.Xr pkg_add 1
+.Xr pkg-add 8
 does.
 .Pp
 The
@@ -630,7 +630,7 @@ writable by the unprivileged user.
 By default
 .Nm
 creates backup packages of installed ports before it runs
-.Xr pkg_delete 1
+.Xr pkg-delete 8
 during an update.
 If that package creation fails it is treated as a serious
 error and the user is prompted.
@@ -866,11 +866,13 @@ to avoid rebuilding ports already rebuilt on previous runs.
 However the first method (delete everything and reinstall) is preferred.
 .Sh SEE ALSO
 .Xr make 1 ,
-.Xr pkg_add 1 ,
-.Xr pkg_delete 1 ,
 .Xr su 1 ,
+.Xr pkg 7 ,
 .Xr ports 7 ,
 .Xr ldconfig 8 ,
+.Xr pkg 8 ,
+.Xr pkg-add 8 ,
+.Xr pkg-delete 8 ,
 .Xr sudo 8
 .Sh AUTHORS
 This

--- a/files/portmaster.8
+++ b/files/portmaster.8
@@ -794,10 +794,15 @@ of the
 .Nm
 command:
 .Pp
+Build and install a port not currently installed:
+.Dl "portmaster foo/fooport"
+.Dl "portmaster foo/fooport@flavor"
+.Pp
 Update one port:
 .Dl "portmaster fooport-1.23 or"
 .Dl "portmaster fooport or"
 .Dl "portmaster foo/fooport"
+.Dl "portmaster foo/fooport@flavor"
 .Pp
 Use a package if available:
 .Dl "portmaster --packages fooport-1.23"

--- a/portmaster
+++ b/portmaster
@@ -3,6 +3,15 @@
 # Copyright (c) 2005-2012 Douglas Barton, All rights reserved
 # Please see detailed copyright below
 
+# <se> DEBUGGING ONLY!!!
+#TESTPAT="^py36-"
+
+#TRACE () {
+#	if [ -n "$BASH_SOURCE" ]; then
+#		echo "<><> ${BASH_LINENO[1]} <><> TRACE $@"
+#	fi
+#}
+
 trap trap_exit INT
 
 umask 022
@@ -305,12 +314,20 @@ safe_exit () {
 	exit ${1:-0}
 } # safe_exit()
 
+flavor_part	() { expr "$1" : ".*@" >/dev/null && echo "${1#*@}"; }
+dir_part	() { echo "${1%@*}"; }
+export_flavor	() { local flavor="$1"; if [ "$FLAVOR" != "$flavor" ]; then
+			pm_v "===>>> Setting FLAVOR to '$flavor' (was '$FLAVOR')";
+			export FLAVOR="$flavor"; fi; }
+ 
 pm_cd     () { builtin cd $1 2>/dev/null || return 1; }
 pm_cd_pd  () { [ -n "$PM_INDEX_ONLY" ] && return 2;
-		builtin cd $pd/$1 2>/dev/null ||
-		fail "Cannot cd to port directory: $pd/$1"; }
+			local dir=$pd/$(dir_part $1);
+			builtin cd $dir 2>/dev/null ||
+			fail "Cannot cd to port directory: $dir"; }
 pm_isdir	() { builtin test -d "$1"; }
-pm_isdir_pd	() { builtin test -d "$pd/$1"; }
+pm_isdir_pd	() { local dir=$pd/$(dir_part "$1");
+			builtin test -d "$dir"; }
 pm_kill   () { kill $* >/dev/null 2>/dev/null; }
 pm_make   () { ( unset -v CUR_DEPS INSTALLED_LIST PM_DEPTH build_l PM_URB_LIST;
 		 /usr/bin/nice /usr/bin/make $PM_MAKE_ARGS $*; ); }
@@ -553,23 +570,26 @@ find_glob_dirs () {
 }
 
 origin_from_pdb () {
+	local flavor pkgname
 
-	pkg query '%o' $1 2>/dev/null && return 0
+	pkgname="$1"
+	flavor=$(pkg annotate -Sq "$pkgname" flavor)
+	pkg query '%o'"${flavor:+@$flavor}" "$pkgname" 2>/dev/null && return
 
-	case "$1" in bsdpan-*) return 3 ;; esac
+	case "$pkgname" in bsdpan-*) return 3 ;; esac
 
-	if pm_islocked "$1"; then
+	if pm_islocked "$pkgname"; then
 		if [ -n "$PM_VERBOSE" -o -n "$LIST_ORIGINS" ]; then
 			# An error above doesn't necessarily mean there's
 			# a problem in +MANIFEST, so don't mention it
-			echo "	===>>> No origin available for $1" >&2
-			echo "	===>>> $pdb/$1/+IGNOREME exists" >&2
+			echo "	===>>> No origin available for $pkgname" >&2
+			echo "	===>>> $pdb/$pkgname/+IGNOREME exists" >&2
 			echo '' >&2
 		fi
 		return 2
 	else
 		# Same as above
-		echo "	===>>> No origin available for $1" >&2
+		echo "	===>>> No origin available for $pkgname" >&2
 		echo '' >&2
 	fi
 	return 1
@@ -637,7 +657,7 @@ for var in "$@" ; do
 				export LOCAL_PACKAGEDIR ;;
 	--delete-packages)	PM_DELETE_PACKAGES=pm_delete_packages
 				export PM_DELETE_PACKAGES ;;
-	-[A-Za-z0-9]*)		newopts="$newopts $var" ;;
+	--flavor=*)		PM_FLAVOR=${var#--flavor=} ;;
 	--update-if-newer)	PM_UPDATE_IF_NEWER=pm_update_if_newer
 				export PM_UPDATE_IF_NEWER ;;
 	--delete-build-only)	PM_DEL_BUILD_ONLY=pm_dbo
@@ -708,7 +728,7 @@ while getopts 'BCDFGHKLPRabde:fghilm:nop:r:stvwx:y' COMMAND_LINE_ARGUMENT ; do
 	m)	export PM_MAKE_ARGS=$OPTARG	# For 'make checksum'
 		ARGS="-m $PM_MAKE_ARGS $ARGS" ;;
 	n)	NO_ACTION=nopt; ARGS="-n $ARGS" ;;
-	o)	REPLACE_ORIGIN=oopt ;;
+	o)	REPLACE_ORIGIN=oopt ;; # -o should take a parameter and $OPTARG should be assigned here
 	p)	fail 'The -p option has been deprecated' ;;
 	r)	PM_URB=ropt
 		if [ -d "$pdb/$OPTARG" ] && pkg info -e $OPTARG; then
@@ -921,9 +941,26 @@ fi	# [ "$$" -eq "$PM_PARENT_PID" ]
 
 #=============== Begin functions relevant to --features and main ===============
 
+# find installed port for given origin (with optional @flavor) in the pkg DB
+# return values:
+# 0 - package name has been printed to STDOUT
+# 1 - no matching installed packages found
 iport_from_origin () {
-	pkg query '%n-%v' ${1} || return 1
-	return
+	local origin flavor pkgname_l pkgname pkgflavor
+
+	origin=$(dir_part "$1")
+	flavor=$(flavor_part "$1")
+	pkgname_l=$(echo $(pkg query '%n-%v' $origin)) || return 1
+	# if multiple flavors registered then fall back to $FLAVOR if no flavor has been passed in $1
+	[ "${pkgname_l}" != "${pkgname_l#* }" ] && : ${flavor:=$FLAVOR}
+	for pkgname in $pkgname_l; do
+		pkgflavor=$(pkg annotate -Sq "$pkgname" flavor)
+		if [ "$pkgflavor" = "$flavor" ]; then
+			echo $pkgname
+			return 0
+		fi
+	done
+	return 1
 }
 
 # Takes default value, optional value, and message as input
@@ -977,61 +1014,69 @@ get_answer_yn () {
 	fi
 }
 
+# Find the new origin for moved ports
+# Set global variable moved_npd on success
+# Return values:
+# 0 - The new origin has been stored in the global variable moved_npd
+# 1 - The port has not been moved to a new origin
 find_moved_port () {
 	# Global: moved_npd
-	local sf iport IFS l reason
+	local sf iport flag IFS moved reason
 
-	sf=$1	# Search for
-	iport=$2
+	sf=$(dir_part "$1")	# Search for origin without flavor
+	iport="$2"		# initial package name
+	flag="$3"		# optional flag "nonfatal"
 
 	# To avoid having each word of the reason treated separately
 	IFS='
 '
-	for l in `grep "^$sf|" $pd/MOVED`; do
-		case "$l" in
+	for moved in `grep "^$sf|" $pd/MOVED`; do
+		case "$moved" in
 		${sf}\|\|*) [ -n "$iport" ] || iport=`iport_from_origin $sf`
 			if pm_islocked $iport; then
 				if [ -n "$PM_VERBOSE" ]; then
 					echo ''
 					echo "	===>>> The $sf port has been deleted"
-					echo "	===>>> Reason: ${l##*|}"
+					echo "	===>>> Reason: ${moved##*|}"
 					echo "	===>>> Skipping it due to +IGNOREME file"
 					echo ''
 				fi
 				return 0
 			else
-				reason=${l##*|}
+				reason=${moved##*|}
 				[ "$3" != 'nonfatal' ] &&
 					fail "The $sf port has been deleted: $reason"
 			fi ;;
-		${sf}\|*) moved_npd=${l#*\|}	# New port directory
+		${sf}\|*) moved_npd=${moved#*\|}	# New port directory
 			moved_npd=${moved_npd%%\|*}
 			echo ''
 			echo "	===>>> The $sf port moved to $moved_npd"
-			echo "	===>>> Reason: ${l##*|}"
+			echo "	===>>> Reason: ${moved##*|}"
 			echo ''
 			find_moved_port $moved_npd ;;
+#			find_moved_port $moved_npd $iport ;; <se> is this required???
 		esac
 	done
 
 	if [ -z "$moved_npd" ]; then
 		if [ -z "$reason" ]; then
 			echo ''
-			echo "	===>>> No $pd/$1 exists, and no information"
-			echo "	===>>> about $1 can be found in $pd/MOVED"
+			echo "	===>>> No $pd/$sf exists, and no information"
+			echo "	===>>> about $sf can be found in $pd/MOVED"
 		else	# Only reached in LIST_PLUS
 			echo "	===>>> The $sf port has been deleted: $reason"
 		fi
 		echo ''
 
-		[ -n "$iport" ] || iport=`iport_from_origin $sf`
+		[ -n "$iport" ] || iport=`iport_from_origin $1` || return 1
 		pm_islocked $iport || return 1
 	fi
 	return 0
 }
 
 all_pkgs_by_origin () {
-	namesorigins=`pkg query -a "%n-%v %o"`
+#<se>	namesorigins=`pkg query -a "%n-%v %o"`
+	namesorigins=`pkg query -a "%n-%v %o" | grep "$TESTPAT"`
 	echo "$namesorigins"
 	return
 }
@@ -1050,7 +1095,7 @@ read_distinfos () {
 			origin=$moved_npd
 		fi
 
-		origin="${pd}/${origin}"
+		origin="${pd}/"$(dir_part $origin)
 
 		if [ -s "${origin}/distinfo" ]; then
 			distinfo="${origin}/distinfo"
@@ -1095,6 +1140,7 @@ read_distinfos_all () {
 	echo ''
 
 	for origin in ${pd}/*/*; do
+#		origin=$(dir_part "$origin")
 		case "${origin#$pd/}" in
 		Mk/*|T*|distfiles/*|packages/*|*/[Mm]akefile*|CVS/*|*/CVS|base/*) continue ;; esac
 
@@ -1129,17 +1175,18 @@ ports_by_category () {
 	local pkg
 
 	pm_v "===>>> Sorting ports by category"
-	roots=`   pkg query -e "%#d = 0 && %#r = 0" "%n-%v"`
-	trunks=`  pkg query -e "%#d = 0 && %#r > 0" "%n-%v"`
-	branches=`pkg query -e "%#d > 0 && %#r > 0" "%n-%v"`
-	leaves=`  pkg query -e "%#d > 0 && %#r = 0" "%n-%v"`
+# <se>
+	roots=`   pkg query -e "%#d = 0 && %#r = 0" "%n-%v"|grep "$TESTPAT"`
+	trunks=`  pkg query -e "%#d = 0 && %#r > 0" "%n-%v"|grep "$TESTPAT"`
+	branches=`pkg query -e "%#d > 0 && %#r > 0" "%n-%v"|grep "$TESTPAT"`
+	leaves=`  pkg query -e "%#d > 0 && %#r = 0" "%n-%v"|grep "$TESTPAT"`
 
 	num_roots=$(echo    $(echo $roots    | wc -w))
 	num_trunks=$(echo   $(echo $trunks   | wc -w))
 	num_branches=$(echo $(echo $branches | wc -w))
 	num_leaves=$(echo   $(echo $leaves   | wc -w))
 
-	num_ports=$(echo $(pkg query -a "%n-%v" | wc -w))
+	num_ports=$(echo $(pkg query -a "%n-%v" | grep "$TESTPAT" | wc -w))
 }
 
 delete_empty_dist_subdirs () {
@@ -1170,9 +1217,10 @@ init_packages_var () {
 }
 
 parse_index () {
-	local line
+	local line origin
 
-	line=`grep -m1 "|${PM_IPD}/${1}|" $PM_INDEX` || return 1
+	origin=$(dir_part $1)
+	line=`grep -m1 "|${PM_IPD}/${origin}|" $PM_INDEX` || return 1
 
 	case "$2" in
 	name)		echo ${line%%|*} ;;
@@ -1411,11 +1459,16 @@ check_force_multi () {
 
 check_for_updates () {
 	# Global: num_updates
-	local nf iport origin port_ver do_update skip
-
+	local nf iport originflavor flavor origin port_ver do_update skip
+#set -x
 	[ "$1" = 'list' -o "$1" = 'multi' ] && { nf=nonfatal; shift; }
 
-	iport=$1 ; origin=${2:-`origin_from_pdb $iport`} || return 0
+	iport=$1
+	originflavor=${2:-`origin_from_pdb $iport`} || return 0
+	flavor=$(flavor_part "$originflavor")
+	export_flavor $flavor
+	flavor_option=${flavor:+FLAVOR=$flavor}
+	origin=$(dir_part "$originflavor")
 
 	if [ -n "$PM_INDEX" ]; then
 		case "$PM_INDEX_PORTS" in
@@ -1425,7 +1478,7 @@ check_for_updates () {
 		esac
 
 		[ -z "$do_update" -a -z "$LIST_PLUS" ] && {
-			check_force_multi $iport $origin || do_update=upd_fm_idx; }
+			check_force_multi $iport $originflavor || do_update=upd_fm_idx; }
 
 		if [ -z "$do_update" -a -n "$PM_INDEX_ONLY" -a -n "$PM_THOROUGH" ]; then
 			port_ver=`parse_index $origin name` || {
@@ -1442,13 +1495,13 @@ check_for_updates () {
 				echo "	===>>> Warning: Unable to cd to $pd/$origin"
 				echo "	===>>> Continuing due to $pdb/$iport/+IGNOREME"
 				echo ''
-				CUR_DEPS="${CUR_DEPS}${iport}:${origin}:"
+				CUR_DEPS="${CUR_DEPS}${iport}:${originflavor}:"
 				return 0
 			else
 				fail "Cannot cd to port directory: $pd/$origin"
 			fi
 		fi
-		port_ver=`pm_make -V PKGNAME`
+		port_ver=`pm_make $flavor_option -V PKGNAME`
 		[ -z "$port_ver" ] && fail "Is $pd/$origin/Makefile missing?"
 	elif [ -z "$do_update" -a -z "$skip" -a -z "$PM_INDEX_ONLY" ]; then
 		find_moved_port $origin $iport $nf
@@ -1458,10 +1511,12 @@ check_for_updates () {
 			if pm_islocked "$iport"; then
 				echo "	===>>> Continuing due to $pdb/$iport/+IGNOREME"
 				echo ''
-				CUR_DEPS="${CUR_DEPS}${iport}:${origin}:"
+				CUR_DEPS="${CUR_DEPS}${iport}:${originflavor}:"
 				return 0
 			else
 				do_update=do_update_moved
+				new_port= # <se> already set to wrong pkg name
+				find_new_port "$moved_npd" && port_ver=$new_port
 			fi
 		fi
 	fi
@@ -1474,7 +1529,7 @@ check_for_updates () {
 			elif [ -n "$LIST" ]; then
 				return 0
 			else
-				check_force_multi $iport $origin || do_update=upd_fm_eq
+				check_force_multi $iport $originflavor || do_update=upd_fm_eq
 				unset port_ver
 			fi
 		else
@@ -1489,12 +1544,12 @@ check_for_updates () {
 			esac
 
 			[ -z "$do_update" ] && {
-				check_force_multi $iport $origin || do_update=upd_fm_ne; }
+				check_force_multi $iport $originflavor || do_update=upd_fm_ne; }
 		fi
 	fi
 
 	if [ -z "$do_update" ]; then
-		[ -z "$LIST_PLUS" ] && CUR_DEPS="${CUR_DEPS}${iport}:${origin}:"
+		[ -z "$LIST_PLUS" ] && CUR_DEPS="${CUR_DEPS}${iport}:${originflavor}:"
 		return 0
 	fi
 
@@ -1517,6 +1572,7 @@ check_for_updates () {
 	# No need for check_exclude here because it is already
 	# run in the places that call check_for_updates().
 	check_interactive $iport $port_ver || return 0
+#TRACE update_port "IPORT=$iport PORT_VER=$port_ver"
 	update_port $iport $port_ver || return 1
 	return 0
 }
@@ -2103,34 +2159,41 @@ update_pm_nu () {
 
 find_new_port () {
 	# Global: new_port
+	local portdir flavor flavor_option
 
 	[ -n "$new_port" ] && return
 
-	if pm_cd_pd $1; then
-		new_port=`pm_make -V PKGNAME`
+	portdir=$(dir_part "$1")
+	flavor=$(flavor_part "$1")
+	flavor_option=${flavor:+FLAVOR=$flavor}
+#	export_flavor $flavor
+	if pm_cd_pd $portdir; then
+		new_port=`pm_make -V PKGNAME ${flavor_option}`
 	else
-		new_port=`parse_index $1 name` ||
-			fail "No entry for $1 in $PM_INDEX"
+		new_port=`parse_index $portdir name` ||
+			fail "No entry for $portdir in $PM_INDEX"
 	fi
 }
 
 update_build_l () {
-	local origin iport
+	local originflavor origin flavor iport
 
-	origin=$1 ; update_pm_nu $origin
+	originflavor=$1 ; update_pm_nu $originflavor
+	origin=$(dir_part "$originflavor")
+	flavor=$(flavor_part "$originflavor")
+	iport="$2"
 
 	[ -n "$PM_NO_CONFIRM" ] && return
 
-	if [ -z "$2" ]; then
+	if [ -z "$iport" ]; then
 		case "$build_l" in *\ $origin\\*) return ;; esac
-		build_l="${build_l}\tInstall $origin\n"
+		build_l="${build_l}\tInstall $originflavor\n" # <se>
 		return
 	else
-		iport=$2
 		case "$build_l" in *\ $iport\ *|*\ $iport\\*) return ;; esac
 	fi
 
-	find_new_port $origin
+	find_new_port "$originflavor" # sets global variable new_port
 
 	case `pkg version -t $iport $new_port 2>/dev/null` in
 	\<)	build_l="${build_l}\tUpgrade $iport to $new_port\n" ;;
@@ -2173,7 +2236,9 @@ update_port () {
 		unset NO_DEP_UPDATES
 
 	if [ -z "$NO_ACTION" -o -n "$PM_FIRST_PASS" ]; then
-		($0 $ARGS $1) || update_failed=update_failed
+# <se>		(bash -x $0 $ARGS $*) || update_failed=update_failed
+#		($0 $ARGS $1) || update_failed=update_failed		
+		($0 $ARGS $*) || update_failed=update_failed		
 		. $IPC_SAVE && > $IPC_SAVE
 		[ -n "$update_failed" ] && fail "Update for $1 failed"
 	else
@@ -2221,12 +2286,30 @@ clean_build_only_list () {
 	build_only_dl_g=" `uniquify_list $temp_bodlg` "
 }
 
+make_dep_list () {
+	local dep_type var_opt
+
+	for dep_type in $*; do
+		case $dep_type in
+		build-depends-list)
+			var_opt="$var_opt -V BUILD_DEPENDS" ;;
+		run-depends-list)
+			var_opt="$var_opt -V RUN_DEPENDS" ;;
+		*)
+			fail "make_dep_list: Unsupported option '$dep_type'"
+		esac
+	done
+	[ -n "$var_opt" ] && make $var_opt | tr ' ' '\n' | cut -d: -f2 | sort -u
+}
+
 gen_dep_list () {
 	local list
 
 	if [ -z "$PM_INDEX_ONLY" ]; then
 		pm_cd_pd $portdir
-		list=`pm_make $* | sort -u`
+#		list=`pm_make FLAVOR=$(flavor_part $portdir) $* | sort -u`
+		export_flavor $(flavor_part $portdir) # <se> required???
+		make_dep_list $*
 	else
 		local temp_list l
 
@@ -2249,6 +2332,9 @@ gen_dep_list () {
 	echo "$list"
 }
 
+#
+#
+# changes PWD!!!
 dependency_check () {
 	# Global: doing_dep_check
 	# Global: run_dl_g build_only_dl_g
@@ -2344,24 +2430,27 @@ dependency_check () {
 			case "$CUR_DEPS" in *:${origin}:*) continue ;; esac
 
 		if [ -z "$PM_INDEX_ONLY" ]; then
-			local conflicts glob confl_p
-
+			local conflicts glob confl_p dir flavor flavor_opt
+			dir=$(dir_part $d_port)
+			flavor=$(flavor_part $d_port)
+			flavor_opt=${flavor:+FLAVOR=$flavor}
 			conflicts=''
-			if pm_cd $d_port; then
+			if pm_cd "$pd/$dir"; then
 				if grep -ql ^CONFLICTS Makefile ; then
-					conflicts=`pm_make_b -V CONFLICTS`
-					conflicts="$conflicts `pm_make_b -V CONFLICTS_BUILD`"
-					conflicts="$conflicts `pm_make_b -V CONFLICTS_INSTALL`"
+					conflicts=`pm_make_b $flavor_opt -V CONFLICTS`
+					conflicts="$conflicts `pm_make_b $flavor_opt -V CONFLICTS_BUILD`"
+					conflicts="$conflicts `pm_make_b $flavor_opt -V CONFLICTS_INSTALL`"
 				fi
 			else
-				fail "Cannot cd to $d_port"
+				fail "Cannot cd to $dir"
 			fi
 			for glob in $conflicts; do
 				confl_p=`pkg query -g "%n-%v" $glob 2>/dev/null`
 				if [ -n "$confl_p" ]; then
 					confl_p=${confl_p%% *}
+echo -e "<><><> Changing d_port from $d_port " 
 					d_port="$pd/`origin_from_pdb $confl_p`"
-
+echo "to $d_port"
 					if [ "${d_port#$pd/}" = "$portdir" ]; then
 						echo -e "\n===>>> $origin seems to depend on $portdir"
 						echo '       which looks like a dependency loop'
@@ -2386,7 +2475,7 @@ dependency_check () {
 				echo "===>>> Forcing update for $pd/$origin"
 				update_port $iport
 			else
-				CUR_DEPS="${CUR_DEPS}${iport}:${origin}:"
+				CUR_DEPS="${CUR_DEPS}${iport}:${originflavor}:"
 			fi
 			continue
 		elif [ -n "$PM_URB_UP" -a -n "$iport" ]; then
@@ -2398,7 +2487,7 @@ dependency_check () {
 				if ! check_restart_and_udf $iport; then
 					update_port $iport
 				else
-					CUR_DEPS="${CUR_DEPS}${iport}:${origin}:"
+					CUR_DEPS="${CUR_DEPS}${iport}:${originflavor}:"
 					PM_URB_DONE="${PM_URB_DONE}${upg_port}:"
 				fi
 				continue ;;
@@ -2815,7 +2904,7 @@ if [ "$$" -eq "$PM_PARENT_PID" -a -z "$SHOW_WORK" ]; then
 		NO_DEP_UPDATES=no_dep_updates ; build_l=''
 		export NO_DEP_UPDATES build_l
 
-		pm_cd_pd Mk && PM_WRKDIRPREFIX=`pm_make_b -V WRKDIRPREFIX` && pm_cd -
+		pm_cd_pd Mk && PM_WRKDIRPREFIX=`pm_make_b -V WRKDIRPREFIX` && pm_cd ~-
 	fi
 
 	if [ -n "$PM_BUILD_ONLY_LIST" ]; then
@@ -2922,7 +3011,7 @@ all_first_pass () {
 	unset roots trunks branches leaves
 
 	for origin in $PM_NEEDS_UPDATE; do
-		case "$PM_NEEDS_UPDATE" in
+		case $PM_NEEDS_UPDATE in
 		*\ $origin\ *)	update_port $origin ;;
 		*)		continue ;;	# Already updated as a dependency
 		esac
@@ -2939,6 +3028,8 @@ no_valid_port () {
 
 # Figure out what we are going to be working on
 if [ -z "$REPLACE_ORIGIN" ]; then
+	export_flavor $(flavor_part $portdir)
+# <se>	portdir=$(dir_part $portdir)
 	[ -n "$portdir" ] && { argv=$portdir ; unset portdir; }
 	argv=${argv:-$1} ; argv=${argv%/} ; argv=`globstrip $argv`
 	case "$argv" in
@@ -2955,8 +3046,8 @@ if [ -z "$REPLACE_ORIGIN" ]; then
 			*)	echo '' ; no_valid_port ;;
 			esac
 		done ;;
-	*)	pm_isdir "$pdb/$argv" && \
-			pkg info -e $argv && \
+#	*)	pm_isdir "$pdb/$argv" && \
+	*)	pkg info -e $argv && \
 			upg_port=$argv ;;
 	esac
 
@@ -2972,6 +3063,8 @@ if [ -z "$REPLACE_ORIGIN" ]; then
 	unset argv
 else
 	portdir="${1#$pd/}" ; portdir="${portdir%/}"
+	export_flavor=$(flavor_part $portdir)
+# <se>	portdir=$(dir_part $portdir)
 	if [ -z "$PM_INDEX_ONLY" ]; then
 		pm_isdir_pd "$portdir" ] || missing=missing
 	else
@@ -2984,8 +3077,9 @@ else
 		echo '' ; no_valid_port
 	fi
 
-	upg_port=`iport_from_origin $portdir`
-
+	# <se> portdir may have been modified (MOVED) making its value invalid!!!
+	upg_port=`iport_from_origin $portdir` || upg_port=$opd # fail "Cannot find installed port '$portdir'"
+#TRACE "UPG_PORT=$upg_port"
 	arg2=${2#$pd/} ; arg2=${arg2#$pdb/} ; arg2=${arg2%/}
 
 	case "$arg2" in
@@ -3002,6 +3096,7 @@ else
 			ro_opd=$arg2
 		fi
 	esac
+	upg_port="${upg_port:-$ro_upg_port}" # <se>
 	unset arg2
 
 	if [ -z "$ro_upg_port" ]; then
@@ -3036,12 +3131,33 @@ fi
 if [ -z "$PM_INDEX_ONLY" ] && ! pm_isdir_pd "$portdir"; then
 	find_moved_port $portdir $upg_port || no_valid_port
 	[ -n "$moved_npd" ] || no_valid_port
-	pm_isdir_pd "$moved_npd" ] || no_valid_port
+	flavor=$(flavor_part "$moved_npd")
+	export_flavor $flavor
+#	flavor_option=${flavor:+-m FLAVOR=$flavor} # FLAVOR is exported in the environment
+	pm_isdir_pd "$moved_npd" || no_valid_port
 
 	[ "$$" -eq "$PM_PARENT_PID" ] && parent_exit
+#echo "===>>> Reinstalling/Upgrading $upg_port moved to $moved_npd"
+#TRACE $0 $ARGS $flavor_option -o $moved_npd $upg_port
+##	exec bash -x $0 $ARGS $flavor_option -o $moved_npd $upg_port # <se> BASH
 	exec $0 $ARGS -o $moved_npd $upg_port
+	# NOT REACHED
 fi
-[ -z "$upg_port" -a -z "$REPLACE_ORIGIN" ] && upg_port=`iport_from_origin ${portdir}`
+
+iport_from_pkgname () {
+	local dir flavor pkgname
+
+	dir=$(dir_part $1)
+	flavor=$(flavor_part $1)
+	pkgname=$(make -C "$pd/$dir" -V PKGNAME FLAVOR=$flavor) || return 1
+	pkg info -x ${pkgname%-*}'-[^-]*'
+}
+
+if [ -z "$upg_port" -a -z "$REPLACE_ORIGIN" ]; then
+	upg_port=`iport_from_origin ${portdir}` ||
+		upg_port=`iport_from_pkgname $portdir`
+	# || fail "XXX Cannot find installed port '$portdir'"
+fi
 
 if pm_islocked "$upg_port"; then
 	# Adding to CUR_DEPS means we will not get here in the build
@@ -3082,7 +3198,8 @@ fi
 # START
 
 if [ -z "$PM_INDEX_ONLY" ]; then
-	pm_cd $pd/$portdir || no_valid_port
+	pm_cd $(dir_part $pd/$portdir) || no_valid_port
+	export_flavor $(flavor_part $portdir)
 else
 	new_port=`parse_index $portdir name` ||
 		fail "No entry for $portdir in $PM_INDEX"
@@ -3498,6 +3615,7 @@ if [ -z "$use_package" ]; then
 	fi
 
 	pm_cd_pd $portdir
+# <se>	export_flavor=$(flavor_part "$portdir")
 	[ -z "$DONT_PRE_CLEAN" ] && { pm_make clean NOCLEANDEPENDS=ncd ||
 		fail 'make clean failed'; }
 
@@ -3525,6 +3643,12 @@ if [ -z "$use_package" ]; then
 
 	[ -n "$PM_NO_MAKE_CONFIG" ] && PM_MAKE_ARGS="$PM_MAKE_ARGS -D_OPTIONS_OK"
 
+# Return flavor for named pkg (must be executed in port directory!)
+pkg_flavor () {
+	local pkg="$1" flavor
+	pm_make pretty-flavors-package-names | sed -ne 's!^\([A-Za-z0-9_]*\): *'$pkg'$!\1!p';
+}
+	export_flavor=$(pkg_flavor $new_port)
 	eval pm_make build $port_log_args || fail "make build failed for $portdir"
 
 	pm_sv Running make stage
@@ -3536,13 +3660,16 @@ else
 		fetch_package $latest_pv || fail "Fetch for ${latest_pv}.tbz failed"; }
 fi
 
+# <se> upg_port is not defined here when updating multiple packages!!! ???
 # Ignore if no old port exists, or -F
+#set -x
 if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 	UPGRADE_PORT="${ro_upg_port:-$upg_port}"
 	UPGRADE_PORT_VER=`echo $UPGRADE_PORT | sed 's#.*-\(.*\)#\1#'`
 	export UPGRADE_PORT UPGRADE_PORT_VER
 
-	[ -z "$NO_BACKUP" ] && pm_pkg_create $pbu $UPGRADE_PORT
+	# <se> the invocation of init_packages should be redundant, but pbu is not defined, without???
+	[ -z "$NO_BACKUP" ] && init_packages && pm_pkg_create "$pbu" $UPGRADE_PORT
 
 	if [ -n "$SAVE_SHARED" ]; then
 		pm_mktemp ldconfig
@@ -3622,9 +3749,9 @@ if [ -n "$FETCH_ONLY" ]; then		# Only reached here if using packages
 fi
 
 install_failed () {
-	local upg_port
+#	local upg_port
 
-	upg_port="${ro_upg_port:-$upg_port}"
+	upg_port="${ro_upg_port:-$upg_port}" # <se> cannot work if upg_port is local!
 
 	if [ -z "$NO_BACKUP" -a -n "$upg_port" ]; then
 		echo ''
@@ -3773,6 +3900,7 @@ fi
 
 
 if [ -n "$upg_port" ]; then
+	upg_port=$(dir_part $upg_port)
 	if [ ! "$upg_port" = "$new_port" ]; then
 		ilist="Upgrade of $upg_port to $new_port"
 	else

--- a/portmaster
+++ b/portmaster
@@ -498,7 +498,7 @@ usage () {
 	echo '-n answer no to all user prompts for the features below'
 	echo '-y answer yes to all user prompts for the features below'
 	echo ''
-	echo '[-n|y] [-b] [-D|d] -e expunge one port via pkg_delete, and remove its distfiles'
+	echo '[-n|y] [-b] [-D|d] -e expunge one port via pkg delete, and remove its distfiles'
 	echo '[-n|y] [-b] [-D|d] -s clean out stale ports that used to be depended on'
 	echo ''
 	echo '[-t] [-n] --clean-distfiles offer to delete stale distfiles'
@@ -1553,7 +1553,7 @@ pm_pkg_create () {
 	fi
 
 	pm_cd $pkgdir || fail "Cannot cd into $pkgdir to create a package"
-	if $PM_SU_CMD pkg create ${PM_PKG_CREATE_OPTS} $2; then
+	if $PM_SU_CMD pkg create $2; then
 		if [ "$1" = "$pbu" ]; then
 			if [ -n "$BACKUP" ]; then
 				echo "	===>>> Package saved to $1" ; echo ''
@@ -1963,7 +1963,6 @@ if [ -n "$CLEAN_STALE" ]; then
 		fi
 
 		echo '' ; pkg info -f $iport
-		pkg_delete="pkg delete"
 
 		get_answer_yn n "\t===>>> ${iport} is no longer depended on, delete"
 		case "$?" in
@@ -2361,7 +2360,7 @@ dependency_check () {
 					if [ "${d_port#$pd/}" = "$portdir" ]; then
 						echo -e "\n===>>> $origin seems to depend on $portdir"
 						echo '       which looks like a dependency loop'
-						fail "Try pkg_updating $portdir"
+						fail "Try pkg updating $portdir"
 					fi
 
 					echo ''
@@ -3384,7 +3383,7 @@ fetch_package () {
 		fi
 		[ -z "$PM_PACKAGES_LOCAL" ] && echo "	${sitepath}"
 		echo ''
-		echo "       Check the pkg_add(1) man page for information"
+		echo "       Check the pkg-add(8) man page for information"
 		echo "       on setting the PACKAGESITE environment variable"
 		[ "$PM_PACKAGES" = only -a -z "$FETCH_ONLY" ] && fail $ponly_err
 		if [ -n "$FETCH_ONLY" ]; then
@@ -3546,8 +3545,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 		    grep -v ^$LOCALBASE_COMPAT > $pm_mktemp_file
 
 		unset temp
-		pkglist="pkg query %Fp"
-		for file in `$pkglist $UPGRADE_PORT |
+		for file in `pkg query %Fp $UPGRADE_PORT |
 		    sort - $pm_mktemp_file | uniq -d`; do
 			temp="${temp}$file "
 		done
@@ -3571,7 +3569,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 	if [ -n "$REPLACE_ORIGIN" -a -n "$ro_upg_port" ]; then
 		# Delete any existing versions of the old port
 		np_orphan=`pkg query "%a" $ro_upg_port`
-		pm_sv "Running pkg_delete for $ro_upg_port"
+		pm_sv "Running pkg delete for $ro_upg_port"
 		pm_pkg_delete_s $ro_upg_port
 	fi
 
@@ -3594,7 +3592,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 		if [ "${np_orphan:-1}" -eq 1 ]; then
 			np_orphan=`pkg query "%a" $upg_port`
 		fi
-		pm_sv "Running pkg_delete for $upg_port"
+		pm_sv "Running pkg delete for $upg_port"
 		pm_pkg_delete_s $upg_port
 	fi
 
@@ -3659,7 +3657,7 @@ else
 	[ -n "$local_package" ] && ppd=${LOCAL_PACKAGEDIR}/All
 
 	echo "===>>> Installing package"
-	if $PM_SU_CMD pkg_add --no-deps --force ${ppd}/${latest_pv}.tbz; then
+	if $PM_SU_CMD pkg add --accept-missing --force ${ppd}/${latest_pv}.tbz; then
 		if [ -n "$PM_DELETE_PACKAGES" ]; then
 			pm_v "===>>> Deleting ${latest_pv}.tbz"
 			pm_unlink_s ${ppd}/${latest_pv}.tbz
@@ -3684,8 +3682,7 @@ echo ''
 temp=`find $LOCALBASE_COMPAT -type d -empty 2>/dev/null`
 if [ -z "$temp" ] && [ -d "$LOCALBASE_COMPAT" ]; then
 	unset files
-	pkglist="pkg query %Fp"
-	for file in `$pkglist $new_port`; do
+	for file in `pkg query %Fp $new_port`; do
 		[ -f "${LOCALBASE_COMPAT}/${file##*/}" ] &&
 			files="${files}${LOCALBASE_COMPAT}/${file##*/} "
 	done

--- a/portmaster
+++ b/portmaster
@@ -318,6 +318,9 @@ pm_mktemp () {
 		fail "mktemp for $1 failed:\n       ${pm_mktemp_file#mktemp: }"
 }
 pm_unlink () { [ -e "$1" ] && /bin/unlink $1; }
+pm_islocked	() { [ -n "$1" ] || return 1;
+			[ -e "$pdb/$1/+IGNOREME" ] && pkg info -e "$1" ||
+			[ `pkg query %k "$1"` -eq "1" ]; }
 
 # Superuser versions for commands that need root privileges
 
@@ -553,7 +556,7 @@ origin_from_pdb () {
 
 	case "$1" in bsdpan-*) return 3 ;; esac
 
-	if [ -e "$pdb/$1/+IGNOREME" ] && pkg info -e $1; then
+	if pm_islocked "$1"; then
 		if [ -n "$PM_VERBOSE" -o -n "$LIST_ORIGINS" ]; then
 			# An error above doesn't necessarily mean there's
 			# a problem in +MANIFEST, so don't mention it
@@ -985,7 +988,7 @@ find_moved_port () {
 	for l in `grep "^$sf|" $pd/MOVED`; do
 		case "$l" in
 		${sf}\|\|*) [ -n "$iport" ] || iport=`iport_from_origin $sf`
-			if [ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport; then
+			if pm_islocked $iport; then
 				if [ -n "$PM_VERBOSE" ]; then
 					echo ''
 					echo "	===>>> The $sf port has been deleted"
@@ -1020,7 +1023,7 @@ find_moved_port () {
 		echo ''
 
 		[ -n "$iport" ] || iport=`iport_from_origin $sf`
-		[ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport || return 1
+		pm_islocked $iport || return 1
 	fi
 	return 0
 }
@@ -1433,7 +1436,7 @@ check_for_updates () {
 
 	if [ -z "$do_update" -a -z "$skip" -a -z "$PM_INDEX_ONLY" ] && [ -d "$pd/$origin" ]; then
 		if ! pm_cd $pd/$origin; then
-			if [ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport; then
+			if pm_islocked "$iport"; then
 				echo "	===>>> Warning: Unable to cd to $pd/$origin"
 				echo "	===>>> Continuing due to $pdb/$iport/+IGNOREME"
 				echo ''
@@ -1450,7 +1453,7 @@ check_for_updates () {
 
 		# If the port has moved and no +IGNOREME, we have to update it
 		if [ -n "$moved_npd" ]; then
-			if [ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport; then
+			if pm_islocked "$iport"; then
 				echo "	===>>> Continuing due to $pdb/$iport/+IGNOREME"
 				echo ''
 				CUR_DEPS="${CUR_DEPS}${iport}:${origin}:"
@@ -1496,7 +1499,7 @@ check_for_updates () {
 	if [ -n "$LIST_PLUS" ]; then
 		if [ -z "$moved_npd" ]; then
 			echo "	===>>> New version available: $port_ver"
-			if [ -e "$pdb/$iport/+IGNOREME" ] && pkg info -e $iport; then
+			if pm_islocked "$iport"; then
 				echo "	===>>> +IGNOREME file is present for $1"
 			fi
 			pm_cd_pd $origin && check_state
@@ -2012,9 +2015,9 @@ check_interactive () {
 	case "$INTERACTIVE_YES" in *:${1}:*) return 0 ;; esac
 	case "$INTERACTIVE_NO" in *:${1}:*) return 1 ;; esac
 
-	if [ -e "$pdb/$1/+IGNOREME" ] && pkg info -e $1; then
+	if pm_islocked $1; then
 		echo ''
-		echo "===>>> +IGNOREME file is present for $1"
+		echo "===>>> package is locked or +IGNOREME file is present for $1"
 		echo ''
 		get_answer_g n y "===>>> Update ${1}${update_to}? y/n"
 
@@ -3038,7 +3041,7 @@ if [ -z "$PM_INDEX_ONLY" ] && [ ! -d "$pd/$portdir" ]; then
 fi
 [ -z "$upg_port" -a -z "$REPLACE_ORIGIN" ] && upg_port=`iport_from_origin ${portdir}`
 
-if [ -e "$pdb/$upg_port/+IGNOREME" ] && pkg info -e $upg_port; then
+if pm_islocked "$upg_port"; then
 	# Adding to CUR_DEPS means we will not get here in the build
 	if [ -z "$PM_BUILDING" ]; then
 		# Only need to prompt for this once if -ai

--- a/portmaster
+++ b/portmaster
@@ -51,7 +51,8 @@ fi
 #=============== Begin functions we always want to have ===============
 
 version () {
-	echo '' ; echo "===>>> Version 3.17.10"
+	local pkgname="%%PKGNAME%%"
+	echo '' ; echo "===>>> Version ${pkgname##*-}"
 	#svn='$FreeBSD: user/dougb/portmaster/portmaster 241090 2012-10-01 08:32:05Z dougb $'
 }
 

--- a/portmaster
+++ b/portmaster
@@ -3,18 +3,13 @@
 # Copyright (c) 2005-2012 Douglas Barton, All rights reserved
 # Please see detailed copyright below
 
-# <se> DEBUGGING ONLY!!!
-#TESTPAT="^py36-"
-
-#TRACE () {
-#	if [ -n "$BASH_SOURCE" ]; then
-#		echo "<><> ${BASH_LINENO[1]} <><> TRACE $@"
-#	fi
-#}
-
 trap trap_exit INT
 
 umask 022
+
+progcmd="$0"			# actual invocation of this program for search in ps output
+progname="${0##*/}"		# program name in messages
+program="$(realpath $0)"	# full path to program for recursive calls
 
 # Initialize crucial values for the parent, and export them for the children
 if [ -z "$PM_PARENT_PID" ]; then
@@ -117,13 +112,13 @@ kill_bad_children () {
 		[ "$pid" -gt 25 ] || continue
 		case "$ppid" in
 		1)	case "$command" in
-			*" $0 "*) pm_kill $pid ;;
+			*" progcmd "*) pm_kill $pid ;;
 			*'make -DBATCH checksum'*|*'/fetch '*|\[sh\]) pm_kill -9 $pid ;;
 			esac ;;
 		*)	[ $pgid -eq $mypgid ] || continue
 			[ $pid -eq $PM_PARENT_PID ] && continue
 			case "$command" in
-			*" $0 "*) pm_kill $pid ;;
+			*" progcmd "*) pm_kill $pid ;;
 			*'make -DBATCH checksum'*|*'/fetch '*|\[sh\]) pm_kill $pid ;;
 			esac ;;
 		esac
@@ -249,10 +244,10 @@ parent_exit () {
 	fi
 
 	if [ -n "$1" -a -n "${PM_NEEDS_UPDATE# }" -a -n "$PM_BUILDING" -a -z "$FETCH_ONLY" ]; then
-		echo "${0##*/} <flags>${PM_NEEDS_UPDATE}" > ${TMPDIR}/portmasterfail.txt
+		echo "$progname <flags>${PM_NEEDS_UPDATE}" > ${TMPDIR}/portmasterfail.txt
 		echo ''
 		echo "===>>> You can restart from the point of failure with this command line:"
-		echo "       ${0##*/} <flags>${PM_NEEDS_UPDATE}"
+		echo "       $progname <flags>${PM_NEEDS_UPDATE}"
 		echo ''
 		echo "This command has been saved to ${TMPDIR}/portmasterfail.txt"
 		echo ''
@@ -315,7 +310,7 @@ safe_exit () {
 } # safe_exit()
 
 flavor_part	() { expr "$1" : ".*@" >/dev/null && echo "${1#*@}"; }
-dir_part	() { echo "${1%@*}"; }
+dir_part	() { echo "${1%%@*}"; }
 export_flavor	() { local flavor="$1"; if [ "$FLAVOR" != "$flavor" ]; then
 			pm_v "===>>> Setting FLAVOR to '$flavor' (was '$FLAVOR')";
 			export FLAVOR="$flavor"; fi; }
@@ -419,42 +414,42 @@ usage () {
 	echo "    [--no-confirm] [--no-term-title] [--no-index-fetch]"
 	echo "    [--index|--index-first|--index-only] [-m <arguments for make>]"
 	echo "    [-x <glob pattern to exclude from building>]"
-	echo "${0##*/} [Common flags] <full name of port directory in $pdb>"
-	echo "${0##*/} [Common flags] <full path to $pd/foo/bar>"
-	echo "${0##*/} [Common flags] <glob pattern of directories in $pdb>"
-	echo "${0##*/} [Common flags] [--update-if-newer] Multiple full names/paths"
+	echo "$progname [Common flags] <full name of port directory in $pdb>"
+	echo "$progname [Common flags] <full path to $pd/foo/bar>"
+	echo "$progname [Common flags] <glob pattern of directories in $pdb>"
+	echo "$progname [Common flags] [--update-if-newer] Multiple full names/paths"
 	echo "         from $pdb|$pd and/or multiple globs from $pdb"
 	echo ''
-	echo "${0##*/} [Common flags] . [Use in $pd/foo/bar to build that port]"
+	echo "$progname [Common flags] . [Use in $pd/foo/bar to build that port]"
 	echo ''
-	echo "${0##*/} [Common flags] -a"
+	echo "$progname [Common flags] -a"
 	echo ''
-	echo "${0##*/} --show-work [-Gv] [-m <args>] <single port, as above>"
+	echo "$progname --show-work [-Gv] [-m <args>] <single port, as above>"
 	echo ''
-	echo "${0##*/} [Common flags] -o <new port dir in $pd> <installed port>"
-	echo "${0##*/} [Common flags] [-R] -r <name/glob of port directory in $pdb>"
+	echo "$progname [Common flags] -o <new port dir in $pd> <installed port>"
+	echo "$progname [Common flags] [-R] -r <name/glob of port directory in $pdb>"
 	echo '         (-r <port> can be specified multiple times)'
 	echo ''
-	echo "${0##*/} -l"
-	echo "${0##*/} [--index-only [-t]] -L"
+	echo "$progname -l"
+	echo "$progname [--index-only [-t]] -L"
 	echo ''
-	echo "${0##*/} --list-origins"
+	echo "$progname --list-origins"
 	echo ''
-	echo "${0##*/} [--force-config|-G] [-P|-PP] [-aftv] -F"
+	echo "$progname [--force-config|-G] [-P|-PP] [-aftv] -F"
 	echo ''
-	echo "${0##*/} [-n|y] [-b] [-D|d] -e <name/glob of a single port in $pdb>"
-	echo "${0##*/} [-n|y] [-b] [-D|d] -s"
+	echo "$progname [-n|y] [-b] [-D|d] -e <name/glob of a single port in $pdb>"
+	echo "$progname [-n|y] [-b] [-D|d] -s"
 	echo ''
-	echo "${0##*/} [-n|y] [-t] --clean-distfiles"
+	echo "$progname [-n|y] [-t] --clean-distfiles"
 	echo ''
-	echo "${0##*/} [-n|y] [--index|--index-only] --clean-packages"
+	echo "$progname [-n|y] [--index|--index-only] --clean-packages"
 	echo ''
-	echo "${0##*/} [-n|y] [--index|--index-only] [-v] --check-depends"
+	echo "$progname [-n|y] [--index|--index-only] [-v] --check-depends"
 	echo ''
-	echo "${0##*/} [-n|y] [-v] --check-port-dbdir"
+	echo "$progname [-n|y] [-v] --check-port-dbdir"
 	echo ''
-	echo "${0##*/} -h|--help"
-	echo "${0##*/} --version"
+	echo "$progname -h|--help"
+	echo "$progname --version"
 	echo ''
 	echo "--force-config run 'make config' for all ports (overrides -G)"
 	echo "-C prevents 'make clean' from being run before building"
@@ -657,7 +652,7 @@ for var in "$@" ; do
 				export LOCAL_PACKAGEDIR ;;
 	--delete-packages)	PM_DELETE_PACKAGES=pm_delete_packages
 				export PM_DELETE_PACKAGES ;;
-	--flavor=*)		PM_FLAVOR=${var#--flavor=} ;;
+#	--flavor=*)		PM_FLAVOR=${var#--flavor=} ;;
 	--update-if-newer)	PM_UPDATE_IF_NEWER=pm_update_if_newer
 				export PM_UPDATE_IF_NEWER ;;
 	--delete-build-only)	PM_DEL_BUILD_ONLY=pm_dbo
@@ -688,7 +683,7 @@ for var in "$@" ; do
 	--show-work)		SHOW_WORK=show ; PM_THOROUGH=thorough ;;
 	--force-config)		export PM_FORCE_CONFIG=pm_force_config ;;
 	--*)			echo "Illegal option $var" ; echo ''
-				echo "===>>> Try ${0##*/} --help"; exit 1 ;;
+				echo "===>>> Try $progname --help"; exit 1 ;;
 	*)			newopts="$newopts $var" ;;
 	esac
 done
@@ -753,7 +748,7 @@ while getopts 'BCDFGHKLPRabde:fghilm:nop:r:stvwx:y' COMMAND_LINE_ARGUMENT ; do
 		esac
 		PM_EXCL="${PM_EXCL}`globstrip ${OPTARG}` " ;;
 	y)	PM_YES=yopt; ARGS="-y $ARGS" ;;
-	*)	echo '' ; echo "===>>> Try ${0##*/} --help"; exit 1 ;;
+	*)	echo '' ; echo "===>>> Try $progname --help"; exit 1 ;;
 	esac
 done
 shift $(( $OPTIND - 1 ))
@@ -815,15 +810,6 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 	# Continue error checking in parent only
 	[ -n "$PM_URB" -o -n "$UPDATE_ALL" ] && [ -n "$1" ] &&
 	    fail 'The -[ar] options are not compatible with other updates'
-
-	if [ -n "$PM_PACKAGES" -o -n "$PM_PACKAGES_BUILD" ]; then
-		unset PM_PACKAGES PM_PACKAGES_BUILD PM_PACKAGES_LOCAL PM_PACKAGES_NEWER PM_ALWAYS_FETCH PM_DELETE_PACKAGES
-		echo "===>>> Package installation support cannot be used with pkgng yet,"
-		echo "       it will be disabled"
-		echo ''
-		[ `/sbin/sysctl -n kern.osreldate 2>/dev/null` -lt 600400 ] &&
-			fail Package installation support requires FreeBSD 6.4 or newer
-	fi
 
 	if [ -n "$PM_INDEX" ] &&
 	    [ -z "$LIST" -a -z "$LIST_ORIGINS" -a -z "$EXPUNGE" -a -z "$CLEAN_STALE" ]; then
@@ -1044,7 +1030,7 @@ find_moved_port () {
 				return 0
 			else
 				reason=${moved##*|}
-				[ "$3" != 'nonfatal' ] &&
+				[ "$flag" != 'nonfatal' ] &&
 					fail "The $sf port has been deleted: $reason"
 			fi ;;
 		${sf}\|*) moved_npd=${moved#*\|}	# New port directory
@@ -1054,7 +1040,6 @@ find_moved_port () {
 			echo "	===>>> Reason: ${moved##*|}"
 			echo ''
 			find_moved_port $moved_npd ;;
-#			find_moved_port $moved_npd $iport ;; <se> is this required???
 		esac
 	done
 
@@ -1075,8 +1060,7 @@ find_moved_port () {
 }
 
 all_pkgs_by_origin () {
-#<se>	namesorigins=`pkg query -a "%n-%v %o"`
-	namesorigins=`pkg query -a "%n-%v %o" | grep "$TESTPAT"`
+	namesorigins=`pkg query -a "%n-%v %o"`
 	echo "$namesorigins"
 	return
 }
@@ -1175,18 +1159,17 @@ ports_by_category () {
 	local pkg
 
 	pm_v "===>>> Sorting ports by category"
-# <se>
-	roots=`   pkg query -e "%#d = 0 && %#r = 0" "%n-%v"|grep "$TESTPAT"`
-	trunks=`  pkg query -e "%#d = 0 && %#r > 0" "%n-%v"|grep "$TESTPAT"`
-	branches=`pkg query -e "%#d > 0 && %#r > 0" "%n-%v"|grep "$TESTPAT"`
-	leaves=`  pkg query -e "%#d > 0 && %#r = 0" "%n-%v"|grep "$TESTPAT"`
+	roots=`   pkg query -e "%#d = 0 && %#r = 0" "%n-%v"`
+	trunks=`  pkg query -e "%#d = 0 && %#r > 0" "%n-%v"`
+	branches=`pkg query -e "%#d > 0 && %#r > 0" "%n-%v"`
+	leaves=`  pkg query -e "%#d > 0 && %#r = 0" "%n-%v"`
 
 	num_roots=$(echo    $(echo $roots    | wc -w))
 	num_trunks=$(echo   $(echo $trunks   | wc -w))
 	num_branches=$(echo $(echo $branches | wc -w))
 	num_leaves=$(echo   $(echo $leaves   | wc -w))
 
-	num_ports=$(echo $(pkg query -a "%n-%v" | grep "$TESTPAT" | wc -w))
+	num_ports=$(echo $(pkg query -a "%n-%v" | wc -w))
 }
 
 delete_empty_dist_subdirs () {
@@ -1357,15 +1340,7 @@ if [ -n "$CLEAN_PACKAGES" ]; then
 fi	# [ -n "$CLEAN_PACKAGES" ]
 
 if [ -n "$CHECK_DEPENDS" ]; then
-	missing_deps=$(pkg check -dn)
-	pkg query "%o %do" | while read origin dep; do
-		for missing_dep in ${missing_deps}; do
-			if [ "${missing_dep}" = "${dep}" ]; then
-				echo "${origin} requires missing ${dep}"
-				break
-			fi
-		done
-	done
+	pkg check -dn
 	exit 0
 fi
 
@@ -1457,10 +1432,28 @@ check_force_multi () {
 	fi
 }
 
+find_new_port () {
+	# Global: new_port
+	local portdir flavor flavor_option
+
+	[ -n "$new_port" ] && return
+
+	portdir=$(dir_part "$1")
+	flavor=$(flavor_part "$1")
+	flavor_option=${flavor:+FLAVOR=$flavor}
+#	export_flavor $flavor
+	if pm_cd_pd $portdir; then
+		new_port=`pm_make -V PKGNAME ${flavor_option}`
+	else
+		new_port=`parse_index $portdir name` ||
+			fail "No entry for $portdir in $PM_INDEX"
+	fi
+}
+
 check_for_updates () {
 	# Global: num_updates
 	local nf iport originflavor flavor origin port_ver do_update skip
-#set -x
+
 	[ "$1" = 'list' -o "$1" = 'multi' ] && { nf=nonfatal; shift; }
 
 	iport=$1
@@ -1515,7 +1508,7 @@ check_for_updates () {
 				return 0
 			else
 				do_update=do_update_moved
-				new_port= # <se> already set to wrong pkg name
+				new_port=""
 				find_new_port "$moved_npd" && port_ver=$new_port
 			fi
 		fi
@@ -1572,7 +1565,6 @@ check_for_updates () {
 	# No need for check_exclude here because it is already
 	# run in the places that call check_for_updates().
 	check_interactive $iport $port_ver || return 0
-#TRACE update_port "IPORT=$iport PORT_VER=$port_ver"
 	update_port $iport $port_ver || return 1
 	return 0
 }
@@ -1631,7 +1623,7 @@ pm_pkg_create () {
 				pm_cd_pd $portdir
 				latest_link=`pm_make -V LATEST_LINK`
 				cd ${1}/Latest
-				$PM_SU_CMD ln -sf ../All/$pkg ${latest_link}.tbz
+				$PM_SU_CMD ln -sf ../All/$pkg ${latest_link}.txz
 			fi
 
 			cd ${1}/${portdir%/*}
@@ -1802,7 +1794,7 @@ set_distfiles_and_subdir () {
 		echo "===>>> $full_port_subdir does not exist, therefore we"
 		echo '       will assume that all relevant distfiles are gone.'
 		echo ''
-		echo "       Try ${0##*/} [-y] --clean-distfiles for a full cleanup"
+		echo "       Try $progname [-y] --clean-distfiles for a full cleanup"
 		echo ''
 		return 3
 	fi
@@ -1867,7 +1859,7 @@ delete_all_distfiles () {
 	case "$rc" in
 	1)	echo ''
 		echo "===>>> No $pd/$origin exists to find the distfile list"
-		echo "       Try ${0##*/} [-y] --clean-distfiles for a full cleanup"
+		echo "       Try $progname [-y] --clean-distfiles for a full cleanup"
 		echo ''
 		if [ -n "$dist_list_files" ]; then
 			local answer f
@@ -1995,16 +1987,16 @@ if [ -n "$EXPUNGE" ]; then
 	echo "===>>> Running pkg delete -f $EXPUNGE"
 	pm_pkg_delete_s $EXPUNGE || fail "pkg delete failed"
 
-	echo '' ; echo "===>>> Running ${0##*/} -s $ARGS"
-	exec $0 -s $ARGS
+	echo '' ; echo "===>>> Running $progname -s $ARGS"
+	exec "$program" -s $ARGS
 	exit 0	# Should not be reached
 fi
 
 if [ -n "$CLEAN_STALE" ]; then
 	[ -z "$no_del_list" ] && export no_del_list=':'
 
-	find_stale_ports="pkg query -ae '%a = 1' '%?r %n-%v' | awk '/^0/ { print \$2 }'"
-	for file in `eval $find_stale_ports` ; do
+	stale_ports=`pkg query -ae '%a = 1' '%?r %n-%v' | awk '/^0 / { print \$2 }'`
+	for file in $stale_ports; do
 		iport="${file%/+REQUIRED_BY}" ; iport=${iport#$pdb/}
 
 		case "$no_del_list" in *:${iport}:*) continue ;; esac
@@ -2018,7 +2010,7 @@ if [ -n "$CLEAN_STALE" ]; then
 				dep=${dep%/+CON*} ; echo "	${dep##*/}"
 			done
 			echo ''
-			echo "===>>> Try ${0##*/} --check-depends"
+			echo "===>>> Try $progname --check-depends"
 			echo ''
 			continue
 		fi
@@ -2033,7 +2025,7 @@ if [ -n "$CLEAN_STALE" ]; then
 			echo "===>>> Running pkg delete -f $iport"
 			pm_pkg_delete_s $iport || fail "pkg delete failed"
 
-			exec $0 -s $ARGS ;;
+			exec "$program" -s $ARGS ;;
 		*)	no_del_list="${no_del_list}${iport}:" ;;
 		esac
 	done
@@ -2148,31 +2140,13 @@ term_printf () {
 	[ -n "$PM_NO_TERM_TITLE" ] && return
 	case "$TERM" in cons*) return ;; esac
 
-	printf "\033]0;${0##*/}: ${PM_PARENT_PORT}${1}\007"
+	printf "\033]0;$progname: ${PM_PARENT_PORT}${1}\007"
 }
 
 update_pm_nu () {
 	case "$PM_NEEDS_UPDATE" in *\ $1\ *) return ;; esac
 
 	PM_NEEDS_UPDATE="${PM_NEEDS_UPDATE}${1} "
-}
-
-find_new_port () {
-	# Global: new_port
-	local portdir flavor flavor_option
-
-	[ -n "$new_port" ] && return
-
-	portdir=$(dir_part "$1")
-	flavor=$(flavor_part "$1")
-	flavor_option=${flavor:+FLAVOR=$flavor}
-#	export_flavor $flavor
-	if pm_cd_pd $portdir; then
-		new_port=`pm_make -V PKGNAME ${flavor_option}`
-	else
-		new_port=`parse_index $portdir name` ||
-			fail "No entry for $portdir in $PM_INDEX"
-	fi
 }
 
 update_build_l () {
@@ -2187,7 +2161,7 @@ update_build_l () {
 
 	if [ -z "$iport" ]; then
 		case "$build_l" in *\ $origin\\*) return ;; esac
-		build_l="${build_l}\tInstall $originflavor\n" # <se>
+		build_l="${build_l}\tInstall $originflavor\n"
 		return
 	else
 		case "$build_l" in *\ $iport\ *|*\ $iport\\*) return ;; esac
@@ -2236,9 +2210,7 @@ update_port () {
 		unset NO_DEP_UPDATES
 
 	if [ -z "$NO_ACTION" -o -n "$PM_FIRST_PASS" ]; then
-# <se>		(bash -x $0 $ARGS $*) || update_failed=update_failed
-#		($0 $ARGS $1) || update_failed=update_failed		
-		($0 $ARGS $*) || update_failed=update_failed		
+		("$program" $ARGS $*) || update_failed=update_failed
 		. $IPC_SAVE && > $IPC_SAVE
 		[ -n "$update_failed" ] && fail "Update for $1 failed"
 	else
@@ -2291,10 +2263,12 @@ make_dep_list () {
 
 	for dep_type in $*; do
 		case $dep_type in
+		all-depends-list)
+			var_opt="$var_opt -V BUILD_DEPENDS -V LIB_DEPENDS -V RUN_DEPENDS" ;;
 		build-depends-list)
-			var_opt="$var_opt -V BUILD_DEPENDS" ;;
+			var_opt="$var_opt -V BUILD_DEPENDS -V LIB_DEPENDS" ;;
 		run-depends-list)
-			var_opt="$var_opt -V RUN_DEPENDS" ;;
+ 			var_opt="$var_opt -V RUN_DEPENDS -V LIB_DEPENDS" ;;
 		*)
 			fail "make_dep_list: Unsupported option '$dep_type'"
 		esac
@@ -2307,8 +2281,7 @@ gen_dep_list () {
 
 	if [ -z "$PM_INDEX_ONLY" ]; then
 		pm_cd_pd $portdir
-#		list=`pm_make FLAVOR=$(flavor_part $portdir) $* | sort -u`
-		export_flavor $(flavor_part $portdir) # <se> required???
+		export_flavor $(flavor_part $portdir)
 		make_dep_list $*
 	else
 		local temp_list l
@@ -2376,7 +2349,7 @@ dependency_check () {
 				continue
 			case "$rundeps" in
 			*" ${dep} "*|*${dep}*)
-				varname=`echo ${dep#$pd/} | sed 's#[-+/\.]#_#g'`
+				varname=`echo ${dep#$pd/} | sed 's#[-+/\.@]#_#g'`
 				rundep_list="$rundep_list $varname"
 				eval $varname=\"$portdir \$$varname\"
 				eval ${varname}_p=$dep
@@ -2448,9 +2421,7 @@ dependency_check () {
 				confl_p=`pkg query -g "%n-%v" $glob 2>/dev/null`
 				if [ -n "$confl_p" ]; then
 					confl_p=${confl_p%% *}
-echo -e "<><><> Changing d_port from $d_port " 
 					d_port="$pd/`origin_from_pdb $confl_p`"
-echo "to $d_port"
 					if [ "${d_port#$pd/}" = "$portdir" ]; then
 						echo -e "\n===>>> $origin seems to depend on $portdir"
 						echo '       which looks like a dependency loop'
@@ -2775,7 +2746,7 @@ multiport () {
 
 		num=$(( $num + 1 ))
 		init_term_printf "$port ${num}/${numports}"
-		($0 $ARGS $port) || update_failed=update_failed
+		("$program" $ARGS $port) || update_failed=update_failed
 		. $IPC_SAVE && > $IPC_SAVE
 		[ -n "$update_failed" ] && fail "Update for $port failed"
 
@@ -2809,7 +2780,12 @@ multiport () {
 				numports=$(( $numports - 1 ))
 				continue
 			fi
-			origin=`origin_from_pdb $port` ;;
+			origin=$(origin_from_pdb $port)
+			unset PM_OLD_ORIGIN
+			if [ -n "$origin" ] && ! pm_isdir_pd "$origin"; then
+				export PM_OLD_ORIGIN=$origin
+				find_moved_port $origin $port nonfatal && origin=$moved_npd
+			fi ;;
 		esac
 
 		case "$PM_NEEDS_UPDATE" in
@@ -2819,7 +2795,7 @@ multiport () {
 
 		num=$(( $num + 1 ))
 		init_term_printf "$port ${num}/${numports}"
-		($0 $ARGS $port) || update_failed=update_failed
+		("$program" $ARGS $port) || update_failed=update_failed
 		. $IPC_SAVE && > $IPC_SAVE
 		[ -n "$update_failed" ] && fail "Update for $port failed"
 	done
@@ -2889,7 +2865,7 @@ if [ "$$" -eq "$PM_PARENT_PID" -a -z "$SHOW_WORK" ]; then
 			files=`find $pdb -type f -name PM_UPGRADE_DONE_FLAG`
 			if [ -n "$files" ]; then
 				echo "===>>> There are 'install complete' flags from a previous"
-				get_answer_g n y "       -[rf] run of ${0##*/}, delete them? y/n"
+				get_answer_g n y "       -[rf] run of $progname, delete them? y/n"
 				case "$?" in
 				1)	pm_sv Deleting \'install complete\' flags
 					pm_find_s $pdb -type f -name PM_UPGRADE_DONE_FLAG -delete ;;
@@ -2904,7 +2880,7 @@ if [ "$$" -eq "$PM_PARENT_PID" -a -z "$SHOW_WORK" ]; then
 		NO_DEP_UPDATES=no_dep_updates ; build_l=''
 		export NO_DEP_UPDATES build_l
 
-		pm_cd_pd Mk && PM_WRKDIRPREFIX=`pm_make_b -V WRKDIRPREFIX` && pm_cd ~-
+		pm_cd_pd Mk && PM_WRKDIRPREFIX=`pm_make_b -V WRKDIRPREFIX` && pm_cd "$OLDPWD"
 	fi
 
 	if [ -n "$PM_BUILD_ONLY_LIST" ]; then
@@ -3023,13 +2999,12 @@ fi	# [ -n "$UPDATE_ALL" ]
 
 no_valid_port () {
 	echo "===>>> No valid installed port, or port directory given"
-	echo "===>>> Try ${0##*/} --help" ; echo '' ; safe_exit 1
+	echo "===>>> Try $progname --help" ; echo '' ; safe_exit 1
 }
 
 # Figure out what we are going to be working on
 if [ -z "$REPLACE_ORIGIN" ]; then
 	export_flavor $(flavor_part $portdir)
-# <se>	portdir=$(dir_part $portdir)
 	[ -n "$portdir" ] && { argv=$portdir ; unset portdir; }
 	argv=${argv:-$1} ; argv=${argv%/} ; argv=`globstrip $argv`
 	case "$argv" in
@@ -3046,9 +3021,7 @@ if [ -z "$REPLACE_ORIGIN" ]; then
 			*)	echo '' ; no_valid_port ;;
 			esac
 		done ;;
-#	*)	pm_isdir "$pdb/$argv" && \
-	*)	pkg info -e $argv && \
-			upg_port=$argv ;;
+	*)	upg_port=$(pkg query %n-%v "$argv") ;;
 	esac
 
 	if [ -z "$portdir" -a -z "$upg_port" ]; then
@@ -3064,7 +3037,6 @@ if [ -z "$REPLACE_ORIGIN" ]; then
 else
 	portdir="${1#$pd/}" ; portdir="${portdir%/}"
 	export_flavor=$(flavor_part $portdir)
-# <se>	portdir=$(dir_part $portdir)
 	if [ -z "$PM_INDEX_ONLY" ]; then
 		pm_isdir_pd "$portdir" ] || missing=missing
 	else
@@ -3077,9 +3049,7 @@ else
 		echo '' ; no_valid_port
 	fi
 
-	# <se> portdir may have been modified (MOVED) making its value invalid!!!
-	upg_port=`iport_from_origin $portdir` || upg_port=$opd # fail "Cannot find installed port '$portdir'"
-#TRACE "UPG_PORT=$upg_port"
+	upg_port=`iport_from_origin $portdir` || upg_port=$opd
 	arg2=${2#$pd/} ; arg2=${arg2#$pdb/} ; arg2=${arg2%/}
 
 	case "$arg2" in
@@ -3096,7 +3066,7 @@ else
 			ro_opd=$arg2
 		fi
 	esac
-	upg_port="${upg_port:-$ro_upg_port}" # <se>
+	upg_port="${upg_port:-$ro_upg_port}"
 	unset arg2
 
 	if [ -z "$ro_upg_port" ]; then
@@ -3137,10 +3107,7 @@ if [ -z "$PM_INDEX_ONLY" ] && ! pm_isdir_pd "$portdir"; then
 	pm_isdir_pd "$moved_npd" || no_valid_port
 
 	[ "$$" -eq "$PM_PARENT_PID" ] && parent_exit
-#echo "===>>> Reinstalling/Upgrading $upg_port moved to $moved_npd"
-#TRACE $0 $ARGS $flavor_option -o $moved_npd $upg_port
-##	exec bash -x $0 $ARGS $flavor_option -o $moved_npd $upg_port # <se> BASH
-	exec $0 $ARGS -o $moved_npd $upg_port
+	exec "$program" $ARGS -o $moved_npd $upg_port
 	# NOT REACHED
 fi
 
@@ -3150,12 +3117,13 @@ iport_from_pkgname () {
 	dir=$(dir_part $1)
 	flavor=$(flavor_part $1)
 	pkgname=$(make -C "$pd/$dir" -V PKGNAME FLAVOR=$flavor) || return 1
-	pkg info -x ${pkgname%-*}'-[^-]*'
+	pkg info -x "^${pkgname%-*}"'-[^-]*' 2>/dev/null
 }
 
 if [ -z "$upg_port" -a -z "$REPLACE_ORIGIN" ]; then
 	upg_port=`iport_from_origin ${portdir}` ||
-		upg_port=`iport_from_pkgname $portdir`
+		upg_port=`iport_from_pkgname $portdir` ||
+		upg_port="$PM_OLD_ORIGIN"
 	# || fail "XXX Cannot find installed port '$portdir'"
 fi
 
@@ -3404,7 +3372,7 @@ fetch_package () {
 	fi
 
 	if [ -z "$PM_ALWAYS_FETCH" ]; then
-		if [ -r "${ppd}/${1}.tbz" ]; then
+		if [ -r "${ppd}/${1}.txz" ]; then
 			pm_v "===>>> Package exists, skipping fetch"
 			return 0
 		else
@@ -3412,7 +3380,7 @@ fetch_package () {
 		fi
 	else
 		do_fetch=do_fetch_always_fetch
-		pm_unlink_s ${ppd}/${1}.tbz
+		pm_unlink_s ${ppd}/${1}.txz
 	fi
 
 	if [ -n "$do_fetch" ]; then
@@ -3424,10 +3392,10 @@ fetch_package () {
 			fi
 		fi
 
-		pm_sv Fetching ${1}.tbz
-		if ! $PM_SU_CMD fetch $FETCH_ARGS -o $ppd ${sitepath}${1}.tbz 2>/dev/null; then
-			pm_unlink_s ${ppd}/${1}.tbz
-			$PM_SU_CMD fetch $FETCH_ARGS -o $ppd ${sitepath}${1}.tbz 2>/dev/null
+		pm_sv Fetching ${1}.txz
+		if ! $PM_SU_CMD fetch $FETCH_ARGS -o $ppd ${sitepath}${1}.txz 2>/dev/null; then
+			pm_unlink_s ${ppd}/${1}.txz
+			$PM_SU_CMD fetch $FETCH_ARGS -o $ppd ${sitepath}${1}.txz 2>/dev/null
 		fi
 	fi
 }
@@ -3441,9 +3409,11 @@ fetch_package () {
 				release=packages-${release%-RELEASE*}-release ;;
 		9\.0-CURRENT*)	release=packages-9-current ;;
 		10\.0-CURRENT*)	release=packages-10-current ;;
-		*RC[0-9]*)	release=${release%-RC[0-9]}
+		11\.0-CURRENT*)	release=packages-11-current ;;
+		12\.0-CURRENT*)	release=packages-12-current ;;
+		*RC[0-9]*)	release=${release%-RC[0-9]*}
 				release=packages-${release}-release ;;
-		*BETA[0-9]*)	release=${release%-BETA[0-9]}
+		*BETA[0-9]*)	release=${release%-BETA[0-9]*}
 				release=packages-${release}-release ;;
 		esac
 
@@ -3460,15 +3430,17 @@ fetch_package () {
 	echo "===>>> Checking package repository for latest available version"
 
 	if [ -n "$LOCAL_PACKAGEDIR" ]; then
-		if [ -r "${LOCAL_PACKAGEDIR}/All/${new_port}.tbz" ]; then
-			local_package=${LOCAL_PACKAGEDIR}/All/${new_port}.tbz
+		pm_v "===>>> ... checking: ${LOCAL_PACKAGEDIR}/All/${new_port}.txz"
+		if [ -r "${LOCAL_PACKAGEDIR}/All/${new_port}.txz" ]; then
+			local_package=${LOCAL_PACKAGEDIR}/All/${new_port}.txz
 			latest_pv=${local_package##*/}
 		fi
 		if [ -z "$latest_pv" -a -z "$PM_INDEX_ONLY" ]; then
 			s=`pm_make -V LATEST_LINK`
-			if [ -r "${LOCAL_PACKAGEDIR}/Latest/${s}.tbz" ]; then
-				local_package=${LOCAL_PACKAGEDIR}/Latest/${s}.tbz
-				latest_pv=`readlink ${LOCAL_PACKAGEDIR}/Latest/${s}.tbz`
+			echo "===>>> ... checking: ${LOCAL_PACKAGEDIR}/Latest/${s}.txz"
+			if [ -r "${LOCAL_PACKAGEDIR}/Latest/${s}.txz" ]; then
+				local_package=${LOCAL_PACKAGEDIR}/Latest/${s}.txz
+				latest_pv=`readlink ${LOCAL_PACKAGEDIR}/Latest/${s}.txz`
 				latest_pv=${latest_pv##*/}
 			else
 				pm_v "===>>> No local package for ${new_port}, attempting fetch"
@@ -3531,7 +3503,7 @@ fetch_package () {
 		fi
 	else
 		latest_pv=${latest_pv#*href=\"}
-		latest_pv=${latest_pv%%\.tbz*}
+		latest_pv=${latest_pv%%\.txz*}
 	fi
 
 notnewer () {
@@ -3615,7 +3587,7 @@ if [ -z "$use_package" ]; then
 	fi
 
 	pm_cd_pd $portdir
-# <se>	export_flavor=$(flavor_part "$portdir")
+	export_flavor $(flavor_part $portdir)
 	[ -z "$DONT_PRE_CLEAN" ] && { pm_make clean NOCLEANDEPENDS=ncd ||
 		fail 'make clean failed'; }
 
@@ -3657,18 +3629,16 @@ pkg_flavor () {
 	eval pm_make -DNO_DEPENDS stage $port_log_args || fail "make stage failed for $portdir"
 else
 	[ -z "$local_package" ] && {
-		fetch_package $latest_pv || fail "Fetch for ${latest_pv}.tbz failed"; }
+		fetch_package $latest_pv || fail "Fetch for ${latest_pv}.txz failed"; }
 fi
 
-# <se> upg_port is not defined here when updating multiple packages!!! ???
 # Ignore if no old port exists, or -F
-#set -x
 if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 	UPGRADE_PORT="${ro_upg_port:-$upg_port}"
 	UPGRADE_PORT_VER=`echo $UPGRADE_PORT | sed 's#.*-\(.*\)#\1#'`
 	export UPGRADE_PORT UPGRADE_PORT_VER
 
-	# <se> the invocation of init_packages should be redundant, but pbu is not defined, without???
+	# the invocation of init_packages should be redundant, but pbu is not defined, without???
 	[ -z "$NO_BACKUP" ] && init_packages && pm_pkg_create "$pbu" $UPGRADE_PORT
 
 	if [ -n "$SAVE_SHARED" ]; then
@@ -3698,7 +3668,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 
 	find_dl_distfiles $portdir
 
-	if [ -n "$REPLACE_ORIGIN" -a -n "$ro_upg_port" ]; then
+	if [ -n "$REPLACE_ORIGIN" -a -n "$ro_upg_port" ]; then # <se> not always true for port moved to flavored version with no version update???
 		# Delete any existing versions of the old port
 		np_orphan=`pkg query "%a" $ro_upg_port`
 		pm_sv "Running pkg delete for $ro_upg_port"
@@ -3709,9 +3679,9 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 	if [ -n "$upg_port" ]; then
 		case " $PM_PRESERVE_PORTS " in
 		*" $portdir "*)
-			preserve_port=`echo $portdir | sed 's#[-+/\.]#_#g'`
+			preserve_port=`echo $portdir | sed 's#[-+/\.@]#_#g'`
 			eval preserve_port_files="\$${preserve_port}_files"
-		preserve_dir=`/usr/bin/mktemp -d ${TMPDIR}/d-${PM_PARENT_PID}-${preserve_port} 2>/dev/null` ||
+			preserve_dir=`/usr/bin/mktemp -d ${TMPDIR}/d-${PM_PARENT_PID}-${preserve_port} 2>/dev/null` ||
 				fail "Could not create a temporary directory for $preserve_port in $TMPDIR"
 			for file in $preserve_port_files; do
 				cp -p $file ${preserve_dir}/ ||
@@ -3749,9 +3719,7 @@ if [ -n "$FETCH_ONLY" ]; then		# Only reached here if using packages
 fi
 
 install_failed () {
-#	local upg_port
-
-	upg_port="${ro_upg_port:-$upg_port}" # <se> cannot work if upg_port is local!
+	upg_port="${ro_upg_port:-$upg_port}"
 
 	if [ -z "$NO_BACKUP" -a -n "$upg_port" ]; then
 		echo ''
@@ -3788,14 +3756,14 @@ if [ -z "$use_package" ]; then
 else
 	[ -n "$local_package" ] && ppd=${LOCAL_PACKAGEDIR}/All
 
-	echo "===>>> Installing package"
-	if $PM_SU_CMD pkg add --accept-missing --force ${ppd}/${latest_pv}.tbz; then
+	echo "===>>> Installing package from: ${ppd}/${latest_pv}.txz"
+	if $PM_SU_CMD pkg add --accept-missing --force ${ppd}/${latest_pv}.txz; then
 		if [ -n "$PM_DELETE_PACKAGES" ]; then
-			pm_v "===>>> Deleting ${latest_pv}.tbz"
-			pm_unlink_s ${ppd}/${latest_pv}.tbz
+			pm_v "===>>> Deleting ${latest_pv}.txz"
+			pm_unlink_s ${ppd}/${latest_pv}.txz
 		fi
 	else
-		install_failed ${latest_pv}.tbz
+		install_failed ${latest_pv}.txz
 	fi
 fi
 

--- a/portmaster
+++ b/portmaster
@@ -1436,7 +1436,7 @@ check_for_updates () {
 		fi
 	fi
 
-	if [ -z "$do_update" -a -z "$skip" -a -z "$PM_INDEX_ONLY" ] && [ -d "$pd/$origin" ]; then
+	if [ -z "$do_update" -a -z "$skip" -a -z "$PM_INDEX_ONLY" ] && pm_isdir "$pd/$origin"; then
 		if ! pm_cd $pd/$origin; then
 			if pm_islocked "$iport"; then
 				echo "	===>>> Warning: Unable to cd to $pd/$origin"

--- a/portmaster
+++ b/portmaster
@@ -152,7 +152,7 @@ parent_exit () {
 	[ -n "$need_kbc" ] && kill_bad_children
 
 	[ -n "$pbu" ] && pbu=`find $pbu -type d -empty 2>/dev/null`
-	if [ -d "$pbu" ]; then
+	if pm_isdir "$pbu"; then
 		pm_sv 'Removing empty backup package directory'
 		pm_rmdir_s $pbu
 	fi
@@ -309,6 +309,8 @@ pm_cd     () { builtin cd $1 2>/dev/null || return 1; }
 pm_cd_pd  () { [ -n "$PM_INDEX_ONLY" ] && return 2;
 		builtin cd $pd/$1 2>/dev/null ||
 		fail "Cannot cd to port directory: $pd/$1"; }
+pm_isdir	() { builtin test -d "$1"; }
+pm_isdir_pd	() { builtin test -d "$pd/$1"; }
 pm_kill   () { kill $* >/dev/null 2>/dev/null; }
 pm_make   () { ( unset -v CUR_DEPS INSTALLED_LIST PM_DEPTH build_l PM_URB_LIST;
 		 /usr/bin/nice /usr/bin/make $PM_MAKE_ARGS $*; ); }
@@ -348,7 +350,7 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 	if [ -z "$pd" ]; then
 		if [ -z "$PORTSDIR" ]; then
 			pd=`pm_make_b -f/usr/share/mk/bsd.port.mk -V PORTSDIR 2>/dev/null`
-			[ -z "$pd" ] && [ -d /usr/ports ] && pd=/usr/ports
+			[ -z "$pd" ] && pm_isdir /usr/ports && pd=/usr/ports
 		else
 			pd=$PORTSDIR
 		fi
@@ -361,14 +363,14 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 
 	if [ -z "$pdb" ]; then
 		if [ -z "$PKG_DBDIR" ]; then
-			[ -d /var/db/pkg ] && pdb=/var/db/pkg
+			pm_isdir /var/db/pkg && pdb=/var/db/pkg
 			[ -z "$pdb" ] &&
 				pdb=`pm_make -f/usr/share/mk/bsd.port.mk -V PKG_DBDIR 2>/dev/null`
 		else
 			pdb=$PKG_DBDIR
 		fi
 		if [ -z "$pdb" ]; then
-			if [ -d /var/db/pkg ]; then
+			if pm_isdir /var/db/pkg; then
 				pdb='/var/db/pkg'
 			else
 				fail 'The value of PKG_DBDIR cannot be empty'
@@ -377,7 +379,7 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 	fi
 	export pdb
 
-	[ -z "$port_dbdir" ] && [ -d /var/db/ports ] && port_dbdir=/var/db/ports
+	[ -z "$port_dbdir" ] && pm_isdir /var/db/ports && port_dbdir=/var/db/ports
 	[ -z "$port_dbdir" ] &&
 		port_dbdir=`pm_make_b -f/usr/share/mk/bsd.port.mk -V PORT_DBDIR 2>/dev/null`
 	[ -n "$port_dbdir" ] && export port_dbdir
@@ -887,7 +889,7 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 			fail 'The value of PORTSDIR cannot be empty'
 		fi
 	else
-		if [ -n "$pd" ] && [ -d "$pd" ]; then
+		if [ -n "$pd" ] && pm_isdir "$pd" ]; then
 			export pd
 		else
 			if [ -z "$DONT_SCRUB_DISTFILES" ]; then
@@ -901,7 +903,7 @@ if [ "$$" -eq "$PM_PARENT_PID" ]; then
 	if [ -z "$DISTDIR" -a "$PM_PACKAGES" != only -a -z "$CHECK_DEPENDS" -a \
 	    -z "$CHECK_PORT_DBDIR" -a -z "$LIST_ORIGINS" ]; then
 		if ! DISTDIR=`pm_make_b -f/usr/share/mk/bsd.port.mk -V DISTDIR 2>/dev/null`; then
-			if [ ! -d "$PWD" ]; then
+			if ! pm_isdir "$PWD"; then
 				echo ''
 				echo "===>>> Your current working directory no longer seems to exist"
 				fail 'Try: cd'
@@ -1042,7 +1044,7 @@ read_distinfos () {
 	echo ''
 
 	all_pkgs_by_origin | while read iport origin; do
-		if [ ! -d "$pd/$origin" ]; then
+		if ! pm_isdir_pd "$origin"; then
 			find_moved_port $origin $iport nonfatal >/dev/null
 			[ -n "$moved_npd" ] || continue
 			origin=$moved_npd
@@ -1096,7 +1098,7 @@ read_distinfos_all () {
 		case "${origin#$pd/}" in
 		Mk/*|T*|distfiles/*|packages/*|*/[Mm]akefile*|CVS/*|*/CVS|base/*) continue ;; esac
 
-		[ -d "$origin" ] || continue
+		pm_isdir "$origin" ] || continue
 
 		if [ -s "${origin}/distinfo" ]; then
 			distinfo="${origin}/distinfo"
@@ -1232,7 +1234,7 @@ if [ -n "$CLEAN_PACKAGES" ]; then
 		origin=${origin#origin: }
 
 		if [ -z "$PM_INDEX" ]; then
-			if [ -d "$pd/$origin" ]; then
+			if pm_isdir_pd "$origin"; then
 				pm_cd $pd/$origin && port_ver=`pm_make -V PKGNAME`
 				[ -n "$port_ver" ] || fail "Is $pd/$origin/Makefile missing?"
 			else
@@ -1320,14 +1322,14 @@ if [ -n "$CHECK_DEPENDS" ]; then
 fi
 
 if [ -n "$CHECK_PORT_DBDIR" ]; then
-	[ -d "$port_dbdir" ] ||
+	pm_isdir "$port_dbdir" ||
 		fail 'PORT_DBIR is empty, or the directory $port_dbdir does not exist'
 
 	unique_list=':'
 
 	echo "===>>> Building list of installed port names"; echo ''
 	while read pkg origin; do
-		if [ ! -d "$pd/$origin" ]; then
+		if ! pm_isdir_pd "$origin"; then
 			find_moved_port $origin $pkg nonfatal >/dev/null
 			[ -n "$moved_npd" ] || continue
 			origin=$moved_npd
@@ -1530,7 +1532,7 @@ init_packages () {
 
 	pbu=$PACKAGES/portmaster-backup
 
-	if [ ! -d "$pbu" ]; then
+	if ! pm_isdir "$pbu"; then
 		pm_sv Creating $pbu
 		pm_mkdir_s $pbu
 	fi
@@ -1641,7 +1643,7 @@ find_dl_distfiles () {
 		pm_unlink_s $dist_list
 
 		local dir=`find ${dist_list%/distfiles} -type d -empty 2>/dev/null`
-		if [ -d "$dir" ]; then
+		if pm_isdir "$dir"; then
 			pm_sv Deleting empty $dir directory
 			pm_rmdir_s $dir
 		fi
@@ -1724,7 +1726,7 @@ make_port_subdir () {
 set_distfiles_and_subdir () {
 	[ -z "$dist_list_files" ] && find_dl_distfiles $1
 
-	if [ -d "$pd/$1" ]; then
+	if pm_isdir_pd "$1"; then
 		pm_cd_pd $1
 	else
 		return 1
@@ -1737,7 +1739,7 @@ set_distfiles_and_subdir () {
 
 	[ -n "$full_port_subdir" ] || make_port_subdir
 
-	if [ -d "$full_port_subdir" ]; then
+	if pm_isdir "$full_port_subdir"; then
 		pm_cd $full_port_subdir || fail "cd to $full_port_subdir failed!"
 	else
 		echo ''
@@ -1905,7 +1907,7 @@ if [ -n "$LIST" -o -n "$LIST_PLUS" ]; then
 fi
 
 if [ -n "$EXPUNGE" ]; then
-	if [ ! -d "$pdb/$EXPUNGE" ] || ! pkg info -e $EXPUNGE; then
+	if ! pm_isdir "$pdb/$EXPUNGE" || ! pkg info -e $EXPUNGE; then
 		find_glob_dirs $EXPUNGE
 		case $? in
 		1)	fail "No such port: $EXPUNGE" ;;
@@ -2589,12 +2591,12 @@ multiport () {
 		port=${port#$pdb/}
 		case "$port" in
 		*/*)	port=${port#$pd/}
-			if [ -n "$PM_INDEX_ONLY" ] || [ -d "$pd/${port}" ]; then
+			if [ -n "$PM_INDEX_ONLY" ] || pm_isdir_pd "${port}"; then
 				worklist_temp="$worklist_temp $port"
 			else
 				fail "$pd/${port} does not exist"
 			fi ;;
-		*)	if [ -d "$pdb/$port" ] && pkg info -e $port; then
+		*)	if pm_isdir "$pdb/$port" && pkg info -e $port; then
 				worklist_temp="$worklist_temp $port"
 			else
 				find_glob_dirs $port
@@ -2776,7 +2778,7 @@ if [ "$$" -eq "$PM_PARENT_PID" -a -z "$SHOW_WORK" ]; then
 			LOCALBASE_COMPAT="$PLB/lib/compat/pkg"
 		else
 			[ -n "$PM_INDEX" ] && PLB=`head -1 $PM_INDEX | cut -f 3 -d\| 2>/dev/null`
-			if [ -n "$PLB" ] && [ -d "$PLB" ]; then
+			if [ -n "$PLB" ] && pm_idsdir "$PLB"; then
 				LOCALBASE_COMPAT="${PLB}/lib/compat/pkg"
 			else
 				echo "===>>> Unable to determine the value of LOCALBASE"
@@ -2829,7 +2831,7 @@ if [ "$$" -eq "$PM_PARENT_PID" -a -z "$SHOW_WORK" ]; then
 	if [ -n "$MAKE_PACKAGE" -a -z "$FETCH_ONLY" ]; then
 		init_packages_var
 
-		if [ ! -d "$PACKAGES" ]; then
+		if ! pm_isdir "$PACKAGES"; then
 			pm_sv Creating $PACKAGES
 			pm_mkdir_s $PACKAGES
 		fi
@@ -2953,7 +2955,7 @@ if [ -z "$REPLACE_ORIGIN" ]; then
 			*)	echo '' ; no_valid_port ;;
 			esac
 		done ;;
-	*)	[ -d "$pdb/$argv" ] && \
+	*)	pm_isdir "$pdb/$argv" && \
 			pkg info -e $argv && \
 			upg_port=$argv ;;
 	esac
@@ -2971,7 +2973,7 @@ if [ -z "$REPLACE_ORIGIN" ]; then
 else
 	portdir="${1#$pd/}" ; portdir="${portdir%/}"
 	if [ -z "$PM_INDEX_ONLY" ]; then
-		[ -d "$pd/$portdir" ] || missing=missing
+		pm_isdir_pd "$portdir" ] || missing=missing
 	else
 		parse_index $portdir name >/dev/null || missing=missing
 	fi
@@ -2988,7 +2990,7 @@ else
 
 	case "$arg2" in
 	*/*)	ro_opd=$arg2 ; ro_upg_port=`iport_from_origin $ro_opd` ;;
-	*)	if [ -d "$pdb/$arg2" ] && pkg info -e $arg2; then
+	*)	if pm_isdir "$pdb/$arg2" && pkg info -e $arg2; then
 			ro_upg_port=$arg2
 		else
 			find_glob_dirs $arg2 && ro_upg_port=${glob_dirs#$pdb/}
@@ -3031,10 +3033,10 @@ elif [ -z "$portdir" ]; then
 	no_valid_port
 fi
 
-if [ -z "$PM_INDEX_ONLY" ] && [ ! -d "$pd/$portdir" ]; then
+if [ -z "$PM_INDEX_ONLY" ] && ! pm_isdir_pd "$portdir"; then
 	find_moved_port $portdir $upg_port || no_valid_port
 	[ -n "$moved_npd" ] || no_valid_port
-	[ -d "$pd/$moved_npd" ] || no_valid_port
+	pm_isdir_pd "$moved_npd" ] || no_valid_port
 
 	[ "$$" -eq "$PM_PARENT_PID" ] && parent_exit
 	exec $0 $ARGS -o $moved_npd $upg_port
@@ -3276,7 +3278,7 @@ fetch_package () {
 		export ppd
 	fi
 
-	[ -d "$ppd" ] || { pm_sv Creating $ppd; pm_mkdir_s $ppd; }
+	pm_isdir "$ppd" ] || { pm_sv Creating $ppd; pm_mkdir_s $ppd; }
 
 	if [ -z "$FETCH_ARGS" ]; then
 		FETCH_ARGS=`pm_make -f/usr/share/mk/bsd.port.mk -V FETCH_ARGS 2>/dev/null`
@@ -3553,7 +3555,7 @@ if [ -n "$upg_port" -o -n "$ro_upg_port" ] && [ -z "$FETCH_ONLY" ]; then
 			temp="${temp}$file "
 		done
 		if [ -n "$temp" ]; then
-			if [ ! -d "$LOCALBASE_COMPAT" ]; then
+			if ! pm_isdir "$LOCALBASE_COMPAT"; then
 				pm_sv "Creating $LOCALBASE_COMPAT for -w"
 				pm_mkdir_s $LOCALBASE_COMPAT
 			fi
@@ -3683,7 +3685,7 @@ echo ''
 # Remove saved libs that match newly installed files
 
 temp=`find $LOCALBASE_COMPAT -type d -empty 2>/dev/null`
-if [ -z "$temp" ] && [ -d "$LOCALBASE_COMPAT" ]; then
+if [ -z "$temp" ] && pm_isdir "$LOCALBASE_COMPAT"; then
 	unset files
 	for file in `pkg query %Fp $new_port`; do
 		[ -f "${LOCALBASE_COMPAT}/${file##*/}" ] &&
@@ -3699,7 +3701,7 @@ if [ -z "$temp" ] && [ -d "$LOCALBASE_COMPAT" ]; then
 fi
 
 [ -z "$temp" ] && temp=`find $LOCALBASE_COMPAT -type d -empty 2>/dev/null`
-if [ -d "$temp" ]; then
+if pm_isdir "$temp"; then
 	pm_sv Deleting the empty $LOCALBASE_COMPAT
 	pm_rmdir_s $temp
 fi


### PR DESCRIPTION
Add fixes for issues and regressions reported since the addition of flavor support.
Add back local package installation support that had been disabled for PKG_NG since its introduction.
Fix references to pre-PKG_NG commands in the man-page.
Add mention of flavor support to man-page (for now in the EXAMPLES section only).