### PR TITLE
Add -U alias for --update-if-newer

### DIFF
--- a/files/portmaster.8
+++ b/files/portmaster.8
@@ -59,7 +59,7 @@ Common Flags:
 .Pp
 .Nm
 .Op Common Flags
-.Op Fl -update-if-newer
+.Op Fl U|--update-if-newer
 .Ar Multiple full names or paths from /usr/ports or /var/db/pkg,
 and/or multiple globs from /var/db/pkg
 .Nm
@@ -396,7 +396,7 @@ requirements.
 .It Fl -delete-build-only
 delete ports that are build-only dependencies after a successful run,
 only if installed this run
-.It Fl -update-if-newer
+.It Fl U|--update-if-newer
 (only for multiple ports listed on the command line)
 do not rebuild/reinstall if the installed version is up to date
 .It Fl P|--packages

--- a/portmaster
+++ b/portmaster
@@ -415,7 +415,7 @@ usage () {
 	echo "$progname [Common flags] <full name of port directory in $pdb>"
 	echo "$progname [Common flags] <full path to $pd/foo/bar>"
 	echo "$progname [Common flags] <glob pattern of directories in $pdb>"
-	echo "$progname [Common flags] [--update-if-newer] Multiple full names/paths"
+	echo "$progname [Common flags] [-U|--update-if-newer] Multiple full names/paths"
 	echo "         from $pdb|$pd and/or multiple globs from $pdb"
 	echo ''
 	echo "$progname [Common flags] . [Use in $pd/foo/bar to build that port]"

--- a/portmaster
+++ b/portmaster
@@ -481,7 +481,7 @@ usage () {
 	echo '--delete-build-only delete ports that are build-only dependencies'
 	echo '   after a successful run, only if installed this run'
 	echo ''
-	echo '--update-if-newer (only for multiple ports listed on command line)'
+	echo '-U|--update-if-newer (only for multiple ports listed on command line)'
 	echo '   do not rebuild/reinstall if the installed version is up to date'
 	echo ''
 	echo '-P|--packages use packages, but build port if not available'
@@ -655,7 +655,7 @@ for var in "$@" ; do
 	--package-format=*)	PACKAGE_FORMAT=${var#--package-format=}
 				export PACKAGE_FORMAT ;;
 #	--flavor=*)		PM_FLAVOR=${var#--flavor=} ;;
-	--update-if-newer)	PM_UPDATE_IF_NEWER=pm_update_if_newer
+	-U|--update-if-newer)	PM_UPDATE_IF_NEWER=pm_update_if_newer
 				export PM_UPDATE_IF_NEWER ;;
 	--delete-build-only)	PM_DEL_BUILD_ONLY=pm_dbo
 				export PM_DEL_BUILD_ONLY ;;


### PR DESCRIPTION
The `--update-if-newer` flag is used frequently but there were no short
version of the flag. `-U` switch is the short form of the same flag.

For example to update all outdated perl modules without unnecessarily
re-installing up-to-date modules one can use:
```
portmaster -dHU p5-\*
```