### PR TITLE
Update IRC Channel Link (libera chat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Portmaster has the following features:
 
 WWW: http://portmaster.github.com
 
-IRC: #portmaster @ Freenode
+IRC: ircs://irc.libera.chat:6697/#portmaster


### PR DESCRIPTION
I've registered the #portmaster channel on the Libera Chat network (under the freebsd GC contact)

Update the IRC link here accordingly.

@stesser I can add you as a channel manager at your convenience.